### PR TITLE
Handle browsers without localStorage support

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -5,6 +5,34 @@ const errLine = document.getElementById('errLine');
 const pauseBtn = document.getElementById('pauseBtn');
 const lastRefresh = document.getElementById('lastRefresh');
 
+const fallbackStore = {};
+
+function storageGet(key){
+  try{
+    return window.localStorage.getItem(key);
+  }catch(e){
+    return Object.prototype.hasOwnProperty.call(fallbackStore, key)
+      ? fallbackStore[key]
+      : null;
+  }
+}
+
+function storageSet(key, value){
+  try{
+    if (value === null){
+      window.localStorage.removeItem(key);
+    }else{
+      window.localStorage.setItem(key, value);
+    }
+  }catch(e){
+    if (value === null){
+      delete fallbackStore[key];
+    }else{
+      fallbackStore[key] = value;
+    }
+  }
+}
+
 let paused = false;
 let prev = {};
 let timer = null;
@@ -16,8 +44,8 @@ function flash(el){
 }
 
 function lsKey(k){ return `announce-k${k}`; }
-function getAnnounce(k){ return localStorage.getItem(lsKey(k)) === 'on'; }
-function setAnnounce(k, val){ localStorage.setItem(lsKey(k), val ? 'on' : 'off'); }
+function getAnnounce(k){ return storageGet(lsKey(k)) === 'on'; }
+function setAnnounce(k, val){ storageSet(lsKey(k), val ? 'on' : 'off'); }
 
 function makeCourtCard(k){
   const section = document.createElement('section');


### PR DESCRIPTION
## Summary
- add a resilient storage helper that falls back when localStorage access is blocked
- update the announcement preference logic to use the safe storage helper

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3ae3f5ddc832abfb47a23f5bcbd3c