### PR TITLE
Add control selector routes for UNO panels

### DIFF
--- a/static/control.css
+++ b/static/control.css
@@ -1,0 +1,88 @@
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: #0f172a;
+  color: #f8fafc;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.control {
+  width: min(560px, 100%);
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 18px;
+  padding: 2.5rem 2rem;
+  box-shadow: 0 25px 45px rgba(15, 23, 42, 0.35);
+}
+
+.control h1 {
+  margin: 0 0 1rem;
+  font-size: 2rem;
+  text-align: center;
+}
+
+.control__lead {
+  margin: 0 0 2rem;
+  text-align: center;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.control__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.control__item {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem 1rem;
+  background: rgba(30, 41, 59, 0.85);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.control__link {
+  color: #38bdf8;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 1.1rem;
+}
+
+.control__link:hover,
+.control__link:focus {
+  text-decoration: underline;
+}
+
+.control__overlay {
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.control__overlay code {
+  font-family: "JetBrains Mono", "SFMono-Regular", "Consolas", monospace;
+  font-size: 0.85rem;
+  background: rgba(148, 163, 184, 0.15);
+  padding: 0.25rem 0.5rem;
+  border-radius: 8px;
+}
+
+.control__empty {
+  text-align: center;
+  margin: 2rem 0 0;
+  color: rgba(226, 232, 240, 0.8);
+}

--- a/static/control.html
+++ b/static/control.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="pl">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>UNO Control — wybór kortu</title>
+  <link rel="stylesheet" href="/static/control.css" />
+</head>
+<body>
+  <main class="control">
+    <h1>UNO Control</h1>
+    {% if korts %}
+      <p class="control__lead">Wybierz kort, aby otworzyć panel sterowania.</p>
+      <ul class="control__list">
+        {% for kort, overlay in korts %}
+          <li class="control__item">
+            <a class="control__link" href="/control/{{ kort }}">Kort {{ kort }}</a>
+            {% if overlay %}
+              <span class="control__overlay">ID: <code>{{ overlay }}</code></span>
+            {% endif %}
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="control__empty">Brak skonfigurowanych kortów.</p>
+    {% endif %}
+  </main>
+</body>
+</html>

--- a/static/uno-control.js
+++ b/static/uno-control.js
@@ -1,5 +1,12 @@
 const qs = new URLSearchParams(location.search);
-const kort = parseInt(qs.get('kort') || '1', 10);
+const appRoot = document.querySelector('#app');
+const kortMeta = document.querySelector('meta[name="kort"]');
+const kortSource = qs.get('kort') || appRoot?.dataset?.kort || kortMeta?.content || '1';
+const parsedKort = Number.parseInt(kortSource, 10);
+const kort = Number.isNaN(parsedKort) ? 1 : parsedKort;
+if (appRoot) {
+  appRoot.dataset.kort = String(kort);
+}
 const $ = sel => document.querySelector(sel);
 const live = (msg, timeout = 800) => {
   const n = $('#live');

--- a/uno-control.html
+++ b/uno-control.html
@@ -4,15 +4,16 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>UNO Control — rozszerzony panel</title>
+  <meta name="kort" content="{{ kort|default('1') }}" />
   <link rel="stylesheet" href="/static/uno-control.css">
   <script src="/static/players.js" defer></script>
   <script src="/static/uno-control.js" defer></script>
 </head>
 <body>
-  <div class="wrap" id="app" data-kort="">
+  <div class="wrap" id="app" data-kort="{{ kort|default('1') }}">
     <header class="header">
       <h1 class="title">
-        <span id="hdr-court">Kort 1</span>
+        <span id="hdr-court">Kort {{ kort|default('1') }}</span>
         <span class="sep">—</span>
         <span id="hdr-a">Zawodnik A</span>
         <span class="vs" aria-hidden="true">|</span>


### PR DESCRIPTION
## Summary
- add helpers to derive available courts and render static templates
- serve a new /control selector page with links to each configured kort
- inject kort identifiers into the UNO control panel when opened via /control/<kort>

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e50a20bfa0832ab549128d470d8c23