### PR TITLE
Ensure UNO control panel initializes state locally

### DIFF
--- a/app.py
+++ b/app.py
@@ -524,9 +524,6 @@ def control_panel(kort_id: str):
     if not normalized:
         abort(404)
 
-    if OVERLAY_IDS and not _is_known_kort(normalized):
-        abort(404)
-
     # ZAWSZE utwórz/upewnij się, że istnieje lokalny stan dla kortu,
     # żeby UI mogło działać nawet bez UNO_ID.
     with STATE_LOCK:


### PR DESCRIPTION
## Summary
- ensure the control panel view always creates local state for a court before rendering so the UI works without UNO IDs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5444facac832abf6813e2e8d6cbc5