### PR TITLE
Refactor UNO control panel into tabbed interface

### DIFF
--- a/static/uno-control.css
+++ b/static/uno-control.css
@@ -10,7 +10,14 @@ html,body{margin:0;background:var(--bg);color:var(--ink);font:18px/1.5 Inter,sys
 .title .vs{display:inline-block;margin:0 8px;color:var(--muted)}
 .players-picker{display:grid;grid-template-columns:1fr 1fr;gap:14px}
 .picker__label{display:block;margin:0 0 6px;color:var(--muted);font-size:14px}
-.grid{display:grid;grid-template-columns:1fr 1fr;gap:18px}
+.tabs{display:flex;flex-wrap:wrap;gap:12px;margin:0 0 18px;padding:0 0 12px;border-bottom:1px solid var(--ring)}
+.tabs__item{border:0;background:transparent;color:var(--muted);font:inherit;font-weight:600;padding:8px 16px;border-radius:999px;cursor:pointer;transition:background .2s ease,color .2s ease}
+.tabs__item:hover{background:#241d30;color:var(--ink)}
+.tabs__item.is-active{background:var(--accent);color:#120c1f}
+.tabs__item:focus{outline:2px solid var(--accent);outline-offset:2px}
+.view-container{min-height:260px}
+.view{display:none}
+.view.is-active{display:block}
 .card{background:var(--panel);border-radius:18px;padding:18px 18px 16px;box-shadow:0 10px 30px #0004,inset 0 0 0 1px #0003}
 .card h2{margin:0 0 10px;font-size:20px}
 .card h3{margin:8px 0;font-size:16px;color:var(--muted)}
@@ -25,6 +32,7 @@ html,body{margin:0;background:var(--bg);color:var(--ink);font:18px/1.5 Inter,sys
 .pill{display:flex;gap:10px;align-items:center}
 .btn{height:44px;padding:0 16px;border-radius:12px;border:1px solid var(--ring);background:#2d2538;color:var(--ink);font-weight:600;cursor:pointer}
 .btn:hover{background:#352b45}
+.btn.is-current{background:var(--accent);color:#120c1f}
 .btn.circle{width:44px;min-width:44px;padding:0;border-radius:50%}
 .btn.ghost{background:transparent}
 .chip{min-width:64px;height:44px;border:1px solid var(--ring);border-radius:12px;background:#271f31;display:grid;place-items:center;font-weight:800}
@@ -46,4 +54,3 @@ html,body{margin:0;background:var(--bg);color:var(--ink);font:18px/1.5 Inter,sys
 .combo__empty{padding:12px;color:var(--muted)}
 .sep{opacity:.5}
 .sr-only{position:absolute;left:-10000px;top:auto;width:1px;height:1px;overflow:hidden}
-@media (max-width:1024px){.grid{grid-template-columns:1fr}}

--- a/uno-control.html
+++ b/uno-control.html
@@ -31,181 +31,204 @@
       </div>
     </header>
 
-    <main class="grid">
-      <section class="card">
-        <h2>Points</h2>
-        <div class="row">
-          <div class="lbl" id="pA-name">Zawodnik A</div>
-          <div class="seg" data-player="A">
-            <button data-cmd="SetPointsPlayerA" data-value="0">0</button>
-            <button data-cmd="SetPointsPlayerA" data-value="15">15</button>
-            <button data-cmd="SetPointsPlayerA" data-value="30">30</button>
-            <button data-cmd="SetPointsPlayerA" data-value="40">40</button>
-            <button data-cmd="SetPointsPlayerA" data-value="ADV">ADV</button>
-          </div>
-          <div class="pill">
-            <button class="btn" data-cmd="IncreasePointsPlayerA">+1</button>
-            <button class="btn" data-cmd="DecreasePointsPlayerA">−1</button>
-          </div>
-        </div>
-        <div class="row">
-          <div class="lbl" id="pB-name">Zawodnik B</div>
-          <div class="seg" data-player="B">
-            <button data-cmd="SetPointsPlayerB" data-value="0">0</button>
-            <button data-cmd="SetPointsPlayerB" data-value="15">15</button>
-            <button data-cmd="SetPointsPlayerB" data-value="30">30</button>
-            <button data-cmd="SetPointsPlayerB" data-value="40">40</button>
-            <button data-cmd="SetPointsPlayerB" data-value="ADV">ADV</button>
-          </div>
-          <div class="pill">
-            <button class="btn" data-cmd="IncreasePointsPlayerB">+1</button>
-            <button class="btn" data-cmd="DecreasePointsPlayerB">−1</button>
-          </div>
-        </div>
-        <div class="row end">
-          <div></div>
-          <div class="pill">
-            <button class="btn ghost" data-cmd="ResetPoints">Reset</button>
-          </div>
-        </div>
-      </section>
+    <main>
+      <nav class="tabs" id="view-tabs" role="tablist" aria-label="Sekcje panelu">
+        <button class="tabs__item is-active" id="tab-points" role="tab" aria-selected="true" data-view="points">Points</button>
+        <button class="tabs__item" id="tab-serve" role="tab" aria-selected="false" data-view="serve">Serve</button>
+        <button class="tabs__item" id="tab-current-set" role="tab" aria-selected="false" data-view="current-set">Current Set</button>
+        <button class="tabs__item" id="tab-tie-break" role="tab" aria-selected="false" data-view="tie-break">Tie-Break</button>
+        <button class="tabs__item" id="tab-match-time" role="tab" aria-selected="false" data-view="match-time">Match Time</button>
+        <button class="tabs__item" id="tab-settings" role="tab" aria-selected="false" data-view="settings">Settings</button>
+      </nav>
 
-      <section class="card">
-        <h2>Serve</h2>
-        <div class="row serve">
-          <button class="btn" data-cmd="SetServe" data-value="none">None</button>
-          <button class="btn" data-cmd="SetServe" data-value="A">Player A</button>
-          <button class="btn" data-cmd="SetServe" data-value="B">Player B</button>
-        </div>
-      </section>
+      <div id="view-container" class="view-container" role="presentation"></div>
 
-      <section class="card">
-        <h2>Current Set</h2>
-        <div class="row">
-          <div class="chip" id="current-set" aria-live="polite">1</div>
-          <div class="pill">
-            <button class="btn circle" data-cmd="DecreaseSet">−</button>
-            <button class="btn circle" data-cmd="IncreaseSet">+</button>
+      <template id="view-points">
+        <section class="view card" data-view="points" role="tabpanel" aria-labelledby="tab-points">
+          <h2>Points</h2>
+          <div class="row">
+            <div class="lbl" id="pA-name">Zawodnik A</div>
+            <div class="seg" data-player="A">
+              <button data-cmd="SetPointsPlayerA" data-value="0">0</button>
+              <button data-cmd="SetPointsPlayerA" data-value="15">15</button>
+              <button data-cmd="SetPointsPlayerA" data-value="30">30</button>
+              <button data-cmd="SetPointsPlayerA" data-value="40">40</button>
+              <button data-cmd="SetPointsPlayerA" data-value="ADV">ADV</button>
+            </div>
+            <div class="pill">
+              <button class="btn" data-cmd="IncreasePointsPlayerA">+1</button>
+              <button class="btn" data-cmd="DecreasePointsPlayerA">−1</button>
+            </div>
           </div>
-        </div>
-        <div class="hr"></div>
+          <div class="row">
+            <div class="lbl" id="pB-name">Zawodnik B</div>
+            <div class="seg" data-player="B">
+              <button data-cmd="SetPointsPlayerB" data-value="0">0</button>
+              <button data-cmd="SetPointsPlayerB" data-value="15">15</button>
+              <button data-cmd="SetPointsPlayerB" data-value="30">30</button>
+              <button data-cmd="SetPointsPlayerB" data-value="40">40</button>
+              <button data-cmd="SetPointsPlayerB" data-value="ADV">ADV</button>
+            </div>
+            <div class="pill">
+              <button class="btn" data-cmd="IncreasePointsPlayerB">+1</button>
+              <button class="btn" data-cmd="DecreasePointsPlayerB">−1</button>
+            </div>
+          </div>
+          <div class="row end">
+            <div></div>
+            <div class="pill">
+              <button class="btn ghost" data-cmd="ResetPoints">Reset</button>
+            </div>
+          </div>
+        </section>
+      </template>
 
-        <h3>Sets and Games</h3>
-        <div class="row">
-          <div class="lbl muted" id="sa-name">Zawodnik A</div>
-          <div class="g3">
-            <div class="box" id="s1a">0</div>
-            <div class="box" id="s2a">0</div>
-            <div class="box" id="s3a">0</div>
+      <template id="view-serve">
+        <section class="view card" data-view="serve" role="tabpanel" aria-labelledby="tab-serve">
+          <h2>Serve</h2>
+          <div class="row serve">
+            <button class="btn" data-cmd="SetServe" data-value="none">None</button>
+            <button class="btn" data-cmd="SetServe" data-value="A">Player A</button>
+            <button class="btn" data-cmd="SetServe" data-value="B">Player B</button>
           </div>
-        </div>
-        <div class="row">
-          <div class="lbl muted" id="sb-name">Zawodnik B</div>
-          <div class="g3">
-            <div class="box" id="s1b">0</div>
-            <div class="box" id="s2b">0</div>
-            <div class="box" id="s3b">0</div>
-          </div>
-        </div>
-        <div class="row end">
-          <div></div>
-          <button class="btn ghost" id="reset-sets">Reset</button>
-        </div>
+        </section>
+      </template>
 
-        <div class="hr"></div>
-        <h3>Current Games</h3>
-        <div class="row">
-          <div class="lbl muted" id="cga-name">Zawodnik A</div>
-          <div class="pill">
-            <div class="chip" id="cga">0</div>
-            <button class="btn circle" data-cmd="DecreaseCurrentSetPlayerA">−</button>
-            <button class="btn circle" data-cmd="IncreaseCurrentSetPlayerA">+</button>
+      <template id="view-current-set">
+        <section class="view card" data-view="current-set" role="tabpanel" aria-labelledby="tab-current-set">
+          <h2>Current Set</h2>
+          <div class="row">
+            <div class="chip" id="current-set" aria-live="polite">1</div>
+            <div class="pill">
+              <button class="btn circle" data-cmd="DecreaseSet">−</button>
+              <button class="btn circle" data-cmd="IncreaseSet">+</button>
+            </div>
           </div>
-        </div>
-        <div class="row">
-          <div class="lbl muted" id="cgb-name">Zawodnik B</div>
-          <div class="pill">
-            <div class="chip" id="cgb">0</div>
-            <button class="btn circle" data-cmd="DecreaseCurrentSetPlayerB">−</button>
-            <button class="btn circle" data-cmd="IncreaseCurrentSetPlayerB">+</button>
-          </div>
-        </div>
-        <div class="row end">
-          <div></div>
-          <button class="btn ghost" id="reset-current-games">Reset</button>
-        </div>
-      </section>
+          <div class="hr"></div>
 
-      <section class="card">
-        <h2>Tie-Break</h2>
-        <div class="row">
-          <div class="lbl muted" id="tba-name">Zawodnik A</div>
-          <div class="pill">
-            <div class="chip" id="tba">0</div>
-            <button class="btn circle" data-cmd="DecreaseTieBreakPlayerA">−</button>
-            <button class="btn circle" data-cmd="IncreaseTieBreakPlayerA">+</button>
+          <h3>Sets and Games</h3>
+          <div class="row">
+            <div class="lbl muted" id="sa-name">Zawodnik A</div>
+            <div class="g3">
+              <div class="box" id="s1a">0</div>
+              <div class="box" id="s2a">0</div>
+              <div class="box" id="s3a">0</div>
+            </div>
           </div>
-        </div>
-        <div class="row">
-          <div class="lbl muted" id="tbb-name">Zawodnik B</div>
-          <div class="pill">
-            <div class="chip" id="tbb">0</div>
-            <button class="btn circle" data-cmd="DecreaseTieBreakPlayerB">−</button>
-            <button class="btn circle" data-cmd="IncreaseTieBreakPlayerB">+</button>
+          <div class="row">
+            <div class="lbl muted" id="sb-name">Zawodnik B</div>
+            <div class="g3">
+              <div class="box" id="s1b">0</div>
+              <div class="box" id="s2b">0</div>
+              <div class="box" id="s3b">0</div>
+            </div>
           </div>
-        </div>
-        <div class="row end">
-          <div></div>
-          <button class="btn ghost" id="reset-tb">Reset</button>
-        </div>
-      </section>
+          <div class="row end">
+            <div></div>
+            <button class="btn ghost" id="reset-sets">Reset</button>
+          </div>
 
-      <section class="card">
-        <h2>Match Time</h2>
-        <div class="row">
-          <div class="lbl">Hours</div>
-          <div class="pill">
-            <div class="chip" id="mt-h">0</div>
-            <button class="btn circle" data-time="-3600">−</button>
-            <button class="btn circle" data-time="+3600">+</button>
+          <div class="hr"></div>
+          <h3>Current Games</h3>
+          <div class="row">
+            <div class="lbl muted" id="cga-name">Zawodnik A</div>
+            <div class="pill">
+              <div class="chip" id="cga">0</div>
+              <button class="btn circle" data-cmd="DecreaseCurrentSetPlayerA">−</button>
+              <button class="btn circle" data-cmd="IncreaseCurrentSetPlayerA">+</button>
+            </div>
           </div>
-        </div>
-        <div class="row">
-          <div class="lbl">Minutes</div>
-          <div class="pill">
-            <div class="chip" id="mt-m">0</div>
-            <button class="btn circle" data-time="-60">−</button>
-            <button class="btn circle" data-time="+60">+</button>
+          <div class="row">
+            <div class="lbl muted" id="cgb-name">Zawodnik B</div>
+            <div class="pill">
+              <div class="chip" id="cgb">0</div>
+              <button class="btn circle" data-cmd="DecreaseCurrentSetPlayerB">−</button>
+              <button class="btn circle" data-cmd="IncreaseCurrentSetPlayerB">+</button>
+            </div>
           </div>
-        </div>
-        <div class="row">
-          <div class="lbl">Seconds</div>
-          <div class="pill">
-            <div class="chip" id="mt-s">0</div>
-            <button class="btn circle" data-time="-1">−</button>
-            <button class="btn circle" data-time="+1">+</button>
+          <div class="row end">
+            <div></div>
+            <button class="btn ghost" id="reset-current-games">Reset</button>
           </div>
-        </div>
-        <div class="row end">
-          <div></div>
-          <div class="pill">
-            <button class="btn" id="mt-play">Play</button>
-            <button class="btn" id="mt-pause">Pause</button>
-            <button class="btn ghost" id="mt-reset">Reset</button>
-          </div>
-        </div>
-      </section>
+        </section>
+      </template>
 
-      <section class="card">
-        <h2>Number of Sets</h2>
-        <div class="row">
-          <select id="modeSel" class="select">
-            <option value="3set">3 Sets</option>
-            <option value="5set">5 Sets</option>
-          </select>
-          <button class="btn" data-cmd="SetMode" data-select="modeSel">Save</button>
-        </div>
-      </section>
+      <template id="view-tie-break">
+        <section class="view card" data-view="tie-break" role="tabpanel" aria-labelledby="tab-tie-break">
+          <h2>Tie-Break</h2>
+          <div class="row">
+            <div class="lbl muted" id="tba-name">Zawodnik A</div>
+            <div class="pill">
+              <div class="chip" id="tba">0</div>
+              <button class="btn circle" data-cmd="DecreaseTieBreakPlayerA">−</button>
+              <button class="btn circle" data-cmd="IncreaseTieBreakPlayerA">+</button>
+            </div>
+          </div>
+          <div class="row">
+            <div class="lbl muted" id="tbb-name">Zawodnik B</div>
+            <div class="pill">
+              <div class="chip" id="tbb">0</div>
+              <button class="btn circle" data-cmd="DecreaseTieBreakPlayerB">−</button>
+              <button class="btn circle" data-cmd="IncreaseTieBreakPlayerB">+</button>
+            </div>
+          </div>
+          <div class="row end">
+            <div></div>
+            <button class="btn ghost" id="reset-tb">Reset</button>
+          </div>
+        </section>
+      </template>
+
+      <template id="view-match-time">
+        <section class="view card" data-view="match-time" role="tabpanel" aria-labelledby="tab-match-time">
+          <h2>Match Time</h2>
+          <div class="row">
+            <div class="lbl">Hours</div>
+            <div class="pill">
+              <div class="chip" id="mt-h">0</div>
+              <button class="btn circle" data-time="-3600">−</button>
+              <button class="btn circle" data-time="+3600">+</button>
+            </div>
+          </div>
+          <div class="row">
+            <div class="lbl">Minutes</div>
+            <div class="pill">
+              <div class="chip" id="mt-m">0</div>
+              <button class="btn circle" data-time="-60">−</button>
+              <button class="btn circle" data-time="+60">+</button>
+            </div>
+          </div>
+          <div class="row">
+            <div class="lbl">Seconds</div>
+            <div class="pill">
+              <div class="chip" id="mt-s">0</div>
+              <button class="btn circle" data-time="-1">−</button>
+              <button class="btn circle" data-time="+1">+</button>
+            </div>
+          </div>
+          <div class="row end">
+            <div></div>
+            <div class="pill">
+              <button class="btn" id="mt-play">Play</button>
+              <button class="btn" id="mt-pause">Pause</button>
+              <button class="btn ghost" id="mt-reset">Reset</button>
+            </div>
+          </div>
+        </section>
+      </template>
+
+      <template id="view-settings">
+        <section class="view card" data-view="settings" role="tabpanel" aria-labelledby="tab-settings">
+          <h2>Number of Sets</h2>
+          <div class="row">
+            <select id="modeSel" class="select">
+              <option value="3set">3 Sets</option>
+              <option value="5set">5 Sets</option>
+            </select>
+            <button class="btn" data-cmd="SetMode" data-select="modeSel">Save</button>
+          </div>
+        </section>
+      </template>
     </main>
 
     <div class="sr-only" aria-live="polite" id="live"></div>


### PR DESCRIPTION
## Summary
- replace the grid of cards with a tabbed navigation menu and per-tab templates
- refresh styles to support the tabs and remove the old two-column grid rules
- update client logic to manage tab activation, lazy rendering, and state updates for each view

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e57173b790832aab1240b30dee4862