### PR TITLE
Improve screen reader grouping for court summary

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -781,38 +781,41 @@ function makeCourtCard(k) {
 
     <div class="score-wrapper">
       <dl class="score-list" aria-labelledby="heading-${k}">
-        <div class="score-row" data-side="A">
-          <dt class="player-cell">
-            <span class="player-flag" id="k${k}-flag-A" aria-hidden="true"></span>
-            <span class="player-name" id="k${k}-name-A">${defaultA}</span>
-          </dt>
-          <dd class="metric points" aria-labelledby="k${k}-label-points k${k}-name-A">
-            <span class="metric-label" id="k${k}-label-points" data-default-label="${pointsLabel}" data-tie-label="${tieBreakLabel}" data-super-label="${superTieBreakLabel}">${pointsLabel}</span>
-            <span class="metric-value points" id="k${k}-pts-A">0</span>
-          </dd>
-          <dd class="metric set-1" aria-labelledby="k${k}-label-set1 k${k}-name-A">
-            <span class="metric-label" id="k${k}-label-set1">${set1Label}</span>
-            <span class="metric-value set set-1" id="k${k}-s1-A">0</span>
-          </dd>
-          <dd class="metric set-2" aria-labelledby="k${k}-label-set2 k${k}-name-A">
-            <span class="metric-label" id="k${k}-label-set2">${set2Label}</span>
-            <span class="metric-value set set-2" id="k${k}-s2-A">0</span>
-          </dd>
-        </div>
-        <div class="score-row" data-side="B">
-          <dt class="player-cell">
-            <span class="player-flag" id="k${k}-flag-B" aria-hidden="true"></span>
-            <span class="player-name" id="k${k}-name-B">${defaultB}</span>
-          </dt>
-          <dd class="metric points" aria-labelledby="k${k}-label-points k${k}-name-B">
-            <span class="metric-value points" id="k${k}-pts-B">0</span>
-          </dd>
-          <dd class="metric set-1" aria-labelledby="k${k}-label-set1 k${k}-name-B">
-            <span class="metric-value set set-1" id="k${k}-s1-B">0</span>
-          </dd>
-          <dd class="metric set-2" aria-labelledby="k${k}-label-set2 k${k}-name-B">
-            <span class="metric-value set set-2" id="k${k}-s2-B">0</span>
-          </dd>
+        <div class="sr-only score-summary" id="k${k}-sr-summary" role="text"></div>
+        <div class="score-rows" aria-hidden="true">
+          <div class="score-row" data-side="A">
+            <dt class="player-cell">
+              <span class="player-flag" id="k${k}-flag-A" aria-hidden="true"></span>
+              <span class="player-name" id="k${k}-name-A">${defaultA}</span>
+            </dt>
+            <dd class="metric points" aria-labelledby="k${k}-label-points k${k}-name-A">
+              <span class="metric-label" id="k${k}-label-points" data-default-label="${pointsLabel}" data-tie-label="${tieBreakLabel}" data-super-label="${superTieBreakLabel}">${pointsLabel}</span>
+              <span class="metric-value points" id="k${k}-pts-A">0</span>
+            </dd>
+            <dd class="metric set-1" aria-labelledby="k${k}-label-set1 k${k}-name-A">
+              <span class="metric-label" id="k${k}-label-set1">${set1Label}</span>
+              <span class="metric-value set set-1" id="k${k}-s1-A">0</span>
+            </dd>
+            <dd class="metric set-2" aria-labelledby="k${k}-label-set2 k${k}-name-A">
+              <span class="metric-label" id="k${k}-label-set2">${set2Label}</span>
+              <span class="metric-value set set-2" id="k${k}-s2-A">0</span>
+            </dd>
+          </div>
+          <div class="score-row" data-side="B">
+            <dt class="player-cell">
+              <span class="player-flag" id="k${k}-flag-B" aria-hidden="true"></span>
+              <span class="player-name" id="k${k}-name-B">${defaultB}</span>
+            </dt>
+            <dd class="metric points" aria-labelledby="k${k}-label-points k${k}-name-B">
+              <span class="metric-value points" id="k${k}-pts-B">0</span>
+            </dd>
+            <dd class="metric set-1" aria-labelledby="k${k}-label-set1 k${k}-name-B">
+              <span class="metric-value set set-1" id="k${k}-s1-B">0</span>
+            </dd>
+            <dd class="metric set-2" aria-labelledby="k${k}-label-set2 k${k}-name-B">
+              <span class="metric-value set set-2" id="k${k}-s2-B">0</span>
+            </dd>
+          </div>
         </div>
       </dl>
     </div>
@@ -1085,7 +1088,7 @@ function applyScoreAria(k, data) {
 
   const summaryParts = [`${nameA} ${acc.versus} ${nameB}`];
   const summaryPointsLabel = tieVisible ? (isSuperTieBreak ? acc.superTieBreak : acc.tieBreak) : acc.points;
-  const pointsSegment = `${summaryPointsLabel}: ${pointsA}:${pointsB}`;
+  const pointsSegment = `${summaryPointsLabel} ${pointsA}:${pointsB}`;
   summaryParts.push(pointsSegment);
 
   const setSegments = [];
@@ -1099,15 +1102,31 @@ function applyScoreAria(k, data) {
     if (!include) return;
     const label = format(acc.setTemplate, { number: index });
     const isActive = currentSet === index;
-    const labelWithState = isActive ? `${label} ${acc.active}` : label;
-    setSegments.push(`${labelWithState}: ${a}:${b}`);
+    const segment = isActive
+      ? `${label}, ${acc.active}, ${a}:${b}`
+      : `${label} ${a}:${b}`;
+    setSegments.push(segment);
   });
-
-  setSegments.forEach(segment => summaryParts.push(segment));
 
   updatePointsLabelText(k, tieVisible, isSuperTieBreak);
 
-  const summary = summaryParts.join('. ');
+  setSegments.forEach(segment => summaryParts.push(segment));
+
+  const summary = summaryParts.join('\n');
+
+  const srSummary = document.getElementById(`k${k}-sr-summary`);
+  if (srSummary) {
+    srSummary.innerHTML = '';
+    summaryParts.forEach((part, idx) => {
+      const line = document.createElement('span');
+      line.textContent = part;
+      srSummary.appendChild(line);
+      if (idx < summaryParts.length - 1) {
+        srSummary.appendChild(document.createElement('br'));
+      }
+    });
+  }
+
   list.setAttribute('aria-label', summary);
   section.setAttribute('aria-label', summary);
 }

--- a/static/styles.css
+++ b/static/styles.css
@@ -494,6 +494,10 @@ main {
   border: 0;
 }
 
+.score-summary {
+  white-space: pre-line;
+}
+
 @media (prefers-reduced-motion: reduce) {
   html {
     scroll-behavior: auto;


### PR DESCRIPTION
## Summary
- add a dedicated screen reader summary block that presents court scores in multi-line groups while hiding the visual grid from assistive tech
- render the computed summary as separate lines (including active set cues) and keep the existing aria-label fallback
- allow the summary block to honor line breaks by overriding the sr-only whitespace rule

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e902440cfc832a91bf78a85d206cec