### PR TITLE
Implement admin panel for history and court configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+# Example environment configuration for wyniki-live
+# Copy this file to .env and adjust the values for your deployment.
+
+# Administrative access
+ADMIN_PASSWORD=change-me
+FLASK_SECRET_KEY=change-this-secret
+
+# Optional legacy password used by older scripts (can be left blank if unused)
+HISTORY_DELETE_PASSWORD=
+
+# Overlays Uno integration
+UNO_BASE=https://app.overlays.uno/apiv2/controlapps
+UNO_AUTH_BEARER=
+
+# Court overlay identifiers
+KORT1_ID=
+KORT2_ID=
+KORT3_ID=
+KORT4_ID=
+
+# Application settings
+PORT=8080
+RPM_PER_COURT=55
+BURST=8
+STATE_LOG_SIZE=200
+MATCH_HISTORY_SIZE=50
+DB_PATH=wyniki_archive.sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 .env.*
+!.env.example
 *.sqlite3
 __pycache__/
 *.pyc

--- a/README.md
+++ b/README.md
@@ -2,7 +2,18 @@
 
 ## Konfiguracja
 
-- `HISTORY_DELETE_PASSWORD` – hasło wymagane przy wywołaniu endpointu `https://score.vestmedia.pl/delete` usuwającego ostatni wpis z historii. Endpoint obsługuje logowanie typu HTTP Basic, więc można go wywołać bezpośrednio z przeglądarki (przeglądarka poprosi o hasło).
+1. Skopiuj plik `.env.example` do `.env` i uzupełnij wymagane wartości.
+2. W pliku `.env` ustaw co najmniej:
+   - `ADMIN_PASSWORD` – hasło potrzebne do zalogowania w panelu administracyjnym.
+   - `FLASK_SECRET_KEY` – dowolny sekret używany do podpisywania sesji administracyjnych.
+   - `KORT{N}_ID` – identyfikatory kortów używane do komunikacji z Overlays Uno (np. `KORT1_ID`).
+   - Pozostałe zmienne (`UNO_BASE`, `UNO_AUTH_BEARER`, `MATCH_HISTORY_SIZE` itd.) są opcjonalne i posiadają wartości domyślne, ale można je dostosować do środowiska wdrożeniowego.
+
+## Panel administracyjny
+
+- Panel dostępny jest pod adresem `/admin` i wymaga zalogowania przy pomocy hasła `ADMIN_PASSWORD`.
+- Po zalogowaniu można uzupełniać metadane każdego wpisu historii (`Kategoria`, `Faza rozgrywek`, nazwiska zawodników) oraz usuwać błędne rekordy. Zmiany są zapisywane w bazie danych i natychmiast pojawiają się na stronie głównej.
+- W sekcji „Korty” można zarządzać identyfikatorami overlay. Podczas pierwszego uruchomienia wartości z `KORT{N}_ID` są importowane do bazy i od tej pory konfiguracja jest utrzymywana w tabeli `courts`. Dodanie nowego kortu lub edycja istniejącego odświeża konfigurację w działającej aplikacji.
 
 ## Dostępność wyników
 

--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,273 @@
+<!DOCTYPE html>
+<html lang="pl">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Panel administracyjny &middot; Wyniki na żywo</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: "Inter", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      }
+      body {
+        margin: 0;
+        padding: 0;
+        background: #f4f6f8;
+        color: #1a1a1a;
+      }
+      @media (prefers-color-scheme: dark) {
+        body {
+          background: #101214;
+          color: #f0f4f8;
+        }
+      }
+      header {
+        background: #0d47a1;
+        color: #fff;
+        padding: 1.5rem;
+        text-align: center;
+      }
+      main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 2rem 1rem 3rem;
+      }
+      h1, h2, h3 {
+        font-weight: 600;
+        margin: 0;
+      }
+      section.panel {
+        background: rgba(255, 255, 255, 0.9);
+        border-radius: 12px;
+        box-shadow: 0 10px 30px rgba(15, 35, 95, 0.1);
+        padding: 2rem;
+        margin-bottom: 2rem;
+      }
+      @media (prefers-color-scheme: dark) {
+        section.panel {
+          background: rgba(19, 23, 32, 0.92);
+          box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
+        }
+      }
+      .hidden {
+        display: none !important;
+      }
+      form {
+        margin: 1.5rem 0;
+        display: grid;
+        gap: 1rem;
+      }
+      label {
+        font-weight: 600;
+        font-size: 0.95rem;
+      }
+      input[type="text"],
+      input[type="password"],
+      input[type="number"] {
+        width: 100%;
+        padding: 0.6rem 0.75rem;
+        border-radius: 8px;
+        border: 1px solid rgba(10, 31, 68, 0.2);
+        font-size: 1rem;
+        background: rgba(255, 255, 255, 0.9);
+        color: inherit;
+      }
+      @media (prefers-color-scheme: dark) {
+        input[type="text"],
+        input[type="password"],
+        input[type="number"] {
+          background: rgba(26, 34, 46, 0.9);
+          border-color: rgba(200, 215, 255, 0.2);
+        }
+      }
+      button {
+        appearance: none;
+        border: none;
+        border-radius: 8px;
+        padding: 0.6rem 1.2rem;
+        font-size: 1rem;
+        font-weight: 600;
+        cursor: pointer;
+        background: linear-gradient(135deg, #1976d2, #0d47a1);
+        color: #fff;
+        transition: transform 0.15s ease, box-shadow 0.2s ease;
+      }
+      button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 10px 20px rgba(25, 118, 210, 0.25);
+      }
+      button.secondary {
+        background: transparent;
+        color: inherit;
+        border: 1px solid rgba(13, 71, 161, 0.4);
+      }
+      button.danger {
+        background: linear-gradient(135deg, #d32f2f, #b71c1c);
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 1rem;
+        font-size: 0.95rem;
+      }
+      th, td {
+        padding: 0.75rem;
+        border-bottom: 1px solid rgba(13, 31, 68, 0.08);
+        vertical-align: top;
+      }
+      thead th {
+        text-align: left;
+        font-size: 0.85rem;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: rgba(13, 31, 68, 0.75);
+      }
+      @media (prefers-color-scheme: dark) {
+        th, td {
+          border-bottom-color: rgba(200, 215, 255, 0.08);
+        }
+        thead th {
+          color: rgba(220, 235, 255, 0.75);
+        }
+      }
+      td.actions {
+        display: flex;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+      }
+      td.actions button {
+        flex: 1 1 auto;
+        min-width: 90px;
+      }
+      .history-empty {
+        text-align: center;
+        padding: 2rem 0;
+        font-style: italic;
+        color: rgba(13, 31, 68, 0.7);
+      }
+      .status-line {
+        margin-top: 1rem;
+        font-size: 0.9rem;
+        min-height: 1.2rem;
+      }
+      .status-line.success {
+        color: #2e7d32;
+      }
+      .status-line.error {
+        color: #c62828;
+      }
+      .court-list {
+        list-style: none;
+        margin: 1rem 0;
+        padding: 0;
+        display: grid;
+        gap: 0.75rem;
+      }
+      .court-item {
+        display: grid;
+        gap: 0.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        align-items: end;
+        padding: 0.75rem 1rem;
+        border-radius: 10px;
+        background: rgba(13, 71, 161, 0.05);
+      }
+      @media (prefers-color-scheme: dark) {
+        .court-item {
+          background: rgba(40, 75, 140, 0.18);
+        }
+      }
+      .court-item strong {
+        font-size: 1.05rem;
+      }
+      .inline-field {
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+      }
+      #login-section p.hint {
+        color: rgba(13, 31, 68, 0.7);
+      }
+      @media (prefers-color-scheme: dark) {
+        #login-section p.hint {
+          color: rgba(220, 235, 255, 0.7);
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Panel administracyjny</h1>
+      <p>Zarządzaj historią meczów i konfiguracją kortów</p>
+    </header>
+    <main>
+      <section class="panel" id="login-section">
+        <h2>Dostęp chroniony</h2>
+        <p class="hint">Podaj hasło administratora, aby uzyskać dostęp do panelu.</p>
+        <form id="login-form" autocomplete="off">
+          <label for="admin-password">Hasło administratora</label>
+          <input type="password" id="admin-password" name="password" required>
+          <button type="submit">Zaloguj się</button>
+          <p class="status-line" id="login-status"></p>
+        </form>
+        <p class="status-line error hidden" id="password-missing">Brak skonfigurowanego hasła administratora. Uzupełnij zmienną <code>ADMIN_PASSWORD</code> w pliku konfiguracyjnym.</p>
+      </section>
+
+      <section class="panel hidden" id="admin-section">
+        <div style="display:flex;justify-content:space-between;align-items:center;gap:1rem;flex-wrap:wrap;">
+          <div>
+            <h2>Historia meczów</h2>
+            <p class="hint">Uzupełnij dane i zapisz zmiany, aby pojawiły się na stronie głównej.</p>
+          </div>
+          <button class="secondary" id="logout-btn">Wyloguj</button>
+        </div>
+        <div class="status-line" id="history-status"></div>
+        <div class="table-wrapper">
+          <table id="history-table">
+            <thead>
+              <tr>
+                <th>Informacje</th>
+                <th>Zawodnik A</th>
+                <th>Zawodnik B</th>
+                <th>Kategoria</th>
+                <th>Faza</th>
+                <th>Akcje</th>
+              </tr>
+            </thead>
+            <tbody id="history-rows">
+              <tr class="history-empty"><td colspan="6">Trwa wczytywanie danych…</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="panel hidden" id="courts-section">
+        <div style="display:flex;justify-content:space-between;align-items:center;gap:1rem;flex-wrap:wrap;">
+          <div>
+            <h2>Korty i identyfikatory overlay</h2>
+            <p class="hint">Identyfikatory overlay są zapisywane w bazie danych i wczytywane przy starcie aplikacji.</p>
+          </div>
+        </div>
+        <ul class="court-list" id="court-list"></ul>
+        <form id="court-form" autocomplete="off">
+          <h3>Dodaj lub zaktualizuj kort</h3>
+          <div class="inline-field">
+            <label for="court-id">Numer kortu</label>
+            <input type="number" id="court-id" name="kort" min="1" step="1" required>
+          </div>
+          <div class="inline-field">
+            <label for="court-overlay">Identyfikator overlay</label>
+            <input type="text" id="court-overlay" name="overlay" required placeholder="np. app_1234567890abcdef">
+          </div>
+          <button type="submit">Zapisz kort</button>
+          <p class="status-line" id="courts-status"></p>
+        </form>
+      </section>
+    </main>
+
+    <script>
+      window.ADMIN_INITIAL = {{ initial_json|safe }};
+    </script>
+    <script type="module" src="/static/js/admin.js"></script>
+  </body>
+</html>

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -1,0 +1,410 @@
+const initial = window.ADMIN_INITIAL || {};
+
+const state = {
+  authenticated: Boolean(initial.authenticated),
+  hasPassword: typeof initial.hasPassword === 'boolean' ? initial.hasPassword : Boolean(window.ADMIN_INITIAL && window.ADMIN_INITIAL.hasPassword),
+  defaultPhase: typeof initial.defaultPhase === 'string' && initial.defaultPhase.trim() ? initial.defaultPhase : 'Grupowa',
+  history: Array.isArray(initial.history) ? initial.history : [],
+  courts: Array.isArray(initial.courts) ? initial.courts : []
+};
+
+const loginSection = document.getElementById('login-section');
+const adminSection = document.getElementById('admin-section');
+const courtsSection = document.getElementById('courts-section');
+const loginForm = document.getElementById('login-form');
+const loginStatus = document.getElementById('login-status');
+const passwordMissing = document.getElementById('password-missing');
+const historyRows = document.getElementById('history-rows');
+const historyStatus = document.getElementById('history-status');
+const logoutBtn = document.getElementById('logout-btn');
+const courtList = document.getElementById('court-list');
+const courtForm = document.getElementById('court-form');
+const courtsStatus = document.getElementById('courts-status');
+
+function setStatus(el, message, type = '') {
+  if (!el) return;
+  el.textContent = message || '';
+  el.classList.remove('success', 'error');
+  if (type) {
+    el.classList.add(type);
+  }
+}
+
+function applyPayload(payload) {
+  if (!payload || typeof payload !== 'object') return;
+  if (typeof payload.hasPassword === 'boolean') {
+    state.hasPassword = payload.hasPassword;
+  }
+  if (typeof payload.defaultPhase === 'string' && payload.defaultPhase.trim()) {
+    state.defaultPhase = payload.defaultPhase.trim();
+  }
+  if (Array.isArray(payload.history)) {
+    state.history = payload.history;
+  }
+  if (Array.isArray(payload.courts)) {
+    state.courts = payload.courts;
+  }
+  if (typeof payload.authenticated === 'boolean') {
+    state.authenticated = payload.authenticated;
+  }
+}
+
+function updateUI() {
+  if (state.authenticated) {
+    loginSection.classList.add('hidden');
+    adminSection.classList.remove('hidden');
+    courtsSection.classList.remove('hidden');
+    renderHistory();
+    renderCourts();
+  } else {
+    adminSection.classList.add('hidden');
+    courtsSection.classList.add('hidden');
+    loginSection.classList.remove('hidden');
+    historyRows.innerHTML = '<tr class="history-empty"><td colspan="6">Zaloguj się, aby zobaczyć historię meczów.</td></tr>';
+    courtList.innerHTML = '';
+  }
+  if (passwordMissing) {
+    if (!state.hasPassword) {
+      passwordMissing.classList.remove('hidden');
+    } else {
+      passwordMissing.classList.add('hidden');
+    }
+  }
+}
+
+function formatTimestamp(iso) {
+  if (!iso) return 'Nieznany czas';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return 'Nieznany czas';
+  return date.toLocaleString('pl-PL', { dateStyle: 'short', timeStyle: 'short' });
+}
+
+function summariseSets(entry) {
+  if (!entry || !entry.sets) return '—';
+  const segments = [];
+  ['set1', 'set2'].forEach((key) => {
+    const set = entry.sets[key];
+    if (!set) return;
+    const base = `${set.A ?? 0}:${set.B ?? 0}`;
+    if (set.tb && set.tb.played && (set.tb.A || set.tb.B)) {
+      segments.push(`${base} (${set.tb.A ?? 0}:${set.tb.B ?? 0})`);
+    } else if (set.A || set.B) {
+      segments.push(base);
+    }
+  });
+  const tie = entry.sets.tie;
+  if (tie && tie.played) {
+    segments.push(`Super tie-break ${tie.A ?? 0}:${tie.B ?? 0}`);
+  }
+  return segments.length ? segments.join(', ') : '—';
+}
+
+function resolvePlayer(entry, side) {
+  const player = entry?.players?.[side] || {};
+  return player.full_name || player.surname || '';
+}
+
+function renderHistory() {
+  if (!historyRows) return;
+  if (!state.history.length) {
+    historyRows.innerHTML = '<tr class="history-empty"><td colspan="6">Brak zapisanych meczów.</td></tr>';
+    return;
+  }
+  historyRows.innerHTML = '';
+  state.history.forEach((entry) => {
+    const row = document.createElement('tr');
+    row.dataset.id = entry.id;
+
+    const infoCell = document.createElement('td');
+    const playerA = resolvePlayer(entry, 'A') || 'Zawodnik A';
+    const playerB = resolvePlayer(entry, 'B') || 'Zawodnik B';
+    infoCell.innerHTML = `
+      <div><strong>Kort ${entry.kort || '?'}</strong></div>
+      <div>${playerA} vs ${playerB}</div>
+      <div>Wynik: ${summariseSets(entry)}</div>
+      <div>Czas gry: ${entry.duration_text || '—'}</div>
+      <div>Zakończono: ${formatTimestamp(entry.ended_at)}</div>
+    `;
+
+    const playerACell = document.createElement('td');
+    const playerAInput = document.createElement('input');
+    playerAInput.type = 'text';
+    playerAInput.name = 'player_a';
+    playerAInput.value = playerA;
+    playerACell.appendChild(playerAInput);
+
+    const playerBCell = document.createElement('td');
+    const playerBInput = document.createElement('input');
+    playerBInput.type = 'text';
+    playerBInput.name = 'player_b';
+    playerBInput.value = playerB;
+    playerBCell.appendChild(playerBInput);
+
+    const categoryCell = document.createElement('td');
+    const categoryInput = document.createElement('input');
+    categoryInput.type = 'text';
+    categoryInput.name = 'category';
+    categoryInput.value = typeof entry.category === 'string' ? entry.category : '';
+    categoryCell.appendChild(categoryInput);
+
+    const phaseCell = document.createElement('td');
+    const phaseInput = document.createElement('input');
+    phaseInput.type = 'text';
+    phaseInput.name = 'phase';
+    phaseInput.value = typeof entry.phase === 'string' && entry.phase.trim() ? entry.phase : state.defaultPhase;
+    phaseCell.appendChild(phaseInput);
+
+    const actionsCell = document.createElement('td');
+    actionsCell.className = 'actions';
+    const saveBtn = document.createElement('button');
+    saveBtn.type = 'button';
+    saveBtn.dataset.action = 'save';
+    saveBtn.textContent = 'Zapisz';
+    const deleteBtn = document.createElement('button');
+    deleteBtn.type = 'button';
+    deleteBtn.dataset.action = 'delete';
+    deleteBtn.textContent = 'Usuń';
+    deleteBtn.classList.add('danger');
+    actionsCell.appendChild(saveBtn);
+    actionsCell.appendChild(deleteBtn);
+
+    row.appendChild(infoCell);
+    row.appendChild(playerACell);
+    row.appendChild(playerBCell);
+    row.appendChild(categoryCell);
+    row.appendChild(phaseCell);
+    row.appendChild(actionsCell);
+
+    historyRows.appendChild(row);
+  });
+}
+
+function renderCourts() {
+  if (!courtList) return;
+  if (!state.courts.length) {
+    courtList.innerHTML = '<li class="history-empty">Brak zapisanych kortów. Dodaj pierwszy identyfikator poniżej.</li>';
+    return;
+  }
+  courtList.innerHTML = '';
+  state.courts.forEach((item) => {
+    const kortId = item.kort;
+    const overlay = item.overlay || '';
+    const li = document.createElement('li');
+    li.className = 'court-item';
+    li.dataset.kort = kortId;
+    const header = document.createElement('div');
+    header.innerHTML = `<strong>Kort ${kortId}</strong>`;
+    const field = document.createElement('div');
+    field.className = 'inline-field';
+    const label = document.createElement('label');
+    label.textContent = 'Identyfikator overlay';
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.value = overlay;
+    input.name = 'overlay';
+    field.appendChild(label);
+    field.appendChild(input);
+    const buttons = document.createElement('div');
+    buttons.className = 'actions';
+    const saveBtn = document.createElement('button');
+    saveBtn.type = 'button';
+    saveBtn.dataset.action = 'save-court';
+    saveBtn.textContent = 'Zapisz';
+    const deleteBtn = document.createElement('button');
+    deleteBtn.type = 'button';
+    deleteBtn.dataset.action = 'delete-court';
+    deleteBtn.textContent = 'Usuń';
+    deleteBtn.classList.add('danger');
+    buttons.appendChild(saveBtn);
+    buttons.appendChild(deleteBtn);
+    li.appendChild(header);
+    li.appendChild(field);
+    li.appendChild(buttons);
+    courtList.appendChild(li);
+  });
+}
+
+async function apiRequest(url, options = {}) {
+  const opts = { ...options };
+  opts.credentials = 'same-origin';
+  opts.headers = { 'Accept': 'application/json', ...(options.headers || {}) };
+  if (opts.body && !opts.headers['Content-Type']) {
+    opts.headers['Content-Type'] = 'application/json';
+  }
+  const response = await fetch(url, opts);
+  let data = null;
+  try {
+    data = await response.json();
+  } catch (err) {
+    data = null;
+  }
+  if (response.status === 401) {
+    applyPayload({ authenticated: false });
+    updateUI();
+    const errorMsg = data && data.error ? data.error : 'Brak autoryzacji';
+    throw new Error(errorMsg);
+  }
+  if (!response.ok || (data && data.ok === false)) {
+    const message = data && (data.error || data.message);
+    throw new Error(message || `Żądanie nie powiodło się (${response.status})`);
+  }
+  if (data && typeof data === 'object' && data.ok) {
+    applyPayload(data);
+  }
+  return data;
+}
+
+async function handleLogin(event) {
+  event.preventDefault();
+  setStatus(loginStatus, 'Logowanie…');
+  const formData = new FormData(loginForm);
+  const password = formData.get('password');
+  try {
+    await apiRequest('/api/admin/session', {
+      method: 'POST',
+      body: JSON.stringify({ password })
+    });
+    loginForm.reset();
+    setStatus(loginStatus, 'Zalogowano pomyślnie.', 'success');
+    updateUI();
+  } catch (error) {
+    setStatus(loginStatus, error.message || 'Nieprawidłowe hasło.', 'error');
+  }
+}
+
+async function handleLogout() {
+  try {
+    await apiRequest('/api/admin/session', { method: 'DELETE' });
+  } catch (error) {
+    console.error('Logout failed', error);
+  } finally {
+    applyPayload({ authenticated: false, history: [], courts: [] });
+    updateUI();
+    setStatus(loginStatus, 'Wylogowano.', 'success');
+  }
+}
+
+function collectRowPayload(row) {
+  const payload = {};
+  row.querySelectorAll('input').forEach((input) => {
+    const key = input.name;
+    if (!key) return;
+    const value = input.value.trim();
+    payload[key] = value;
+  });
+  return payload;
+}
+
+async function handleHistoryClick(event) {
+  const button = event.target.closest('button[data-action]');
+  if (!button) return;
+  const row = button.closest('tr[data-id]');
+  if (!row) return;
+  const entryId = row.dataset.id;
+  if (!entryId) return;
+  if (button.dataset.action === 'save') {
+    const payload = collectRowPayload(row);
+    try {
+      setStatus(historyStatus, 'Zapisywanie zmian…');
+      await apiRequest(`/api/admin/history/${entryId}`, {
+        method: 'PUT',
+        body: JSON.stringify(payload)
+      });
+      setStatus(historyStatus, 'Zapisano zmiany.', 'success');
+      renderHistory();
+    } catch (error) {
+      setStatus(historyStatus, error.message || 'Nie udało się zapisać zmian.', 'error');
+    }
+  } else if (button.dataset.action === 'delete') {
+    if (!confirm('Czy na pewno chcesz usunąć ten wpis z historii?')) {
+      return;
+    }
+    try {
+      setStatus(historyStatus, 'Usuwanie wpisu…');
+      await apiRequest(`/api/admin/history/${entryId}`, { method: 'DELETE' });
+      setStatus(historyStatus, 'Usunięto wpis.', 'success');
+      renderHistory();
+    } catch (error) {
+      setStatus(historyStatus, error.message || 'Nie udało się usunąć wpisu.', 'error');
+    }
+  }
+}
+
+async function handleCourtClick(event) {
+  const button = event.target.closest('button[data-action]');
+  if (!button) return;
+  const item = button.closest('[data-kort]');
+  if (!item) return;
+  const kortId = item.dataset.kort;
+  const overlayInput = item.querySelector('input[name="overlay"]');
+  const overlay = overlayInput ? overlayInput.value.trim() : '';
+  if (button.dataset.action === 'save-court') {
+    if (!overlay) {
+      setStatus(courtsStatus, 'Podaj identyfikator overlay.', 'error');
+      return;
+    }
+    try {
+      setStatus(courtsStatus, 'Zapisywanie kortu…');
+      await apiRequest(`/api/admin/courts/${encodeURIComponent(kortId)}`, {
+        method: 'PUT',
+        body: JSON.stringify({ overlay })
+      });
+      setStatus(courtsStatus, `Kort ${kortId} zapisany.`, 'success');
+      renderCourts();
+    } catch (error) {
+      setStatus(courtsStatus, error.message || 'Nie udało się zapisać kortu.', 'error');
+    }
+  } else if (button.dataset.action === 'delete-court') {
+    if (!confirm(`Czy na pewno usunąć kort ${kortId}?`)) return;
+    try {
+      setStatus(courtsStatus, 'Usuwanie kortu…');
+      await apiRequest(`/api/admin/courts/${encodeURIComponent(kortId)}`, { method: 'DELETE' });
+      setStatus(courtsStatus, `Kort ${kortId} usunięty.`, 'success');
+      renderCourts();
+    } catch (error) {
+      setStatus(courtsStatus, error.message || 'Nie udało się usunąć kortu.', 'error');
+    }
+  }
+}
+
+async function handleCourtForm(event) {
+  event.preventDefault();
+  const formData = new FormData(courtForm);
+  const kort = (formData.get('kort') || '').toString().trim();
+  const overlay = (formData.get('overlay') || '').toString().trim();
+  if (!kort || !overlay) {
+    setStatus(courtsStatus, 'Uzupełnij numer kortu i identyfikator overlay.', 'error');
+    return;
+  }
+  try {
+    setStatus(courtsStatus, 'Zapisywanie kortu…');
+    await apiRequest('/api/admin/courts', {
+      method: 'POST',
+      body: JSON.stringify({ kort, overlay })
+    });
+    courtForm.reset();
+    setStatus(courtsStatus, `Kort ${kort} zapisany.`, 'success');
+    renderCourts();
+  } catch (error) {
+    setStatus(courtsStatus, error.message || 'Nie udało się zapisać kortu.', 'error');
+  }
+}
+
+if (loginForm) {
+  loginForm.addEventListener('submit', handleLogin);
+}
+if (logoutBtn) {
+  logoutBtn.addEventListener('click', handleLogout);
+}
+if (historyRows) {
+  historyRows.addEventListener('click', handleHistoryClick);
+}
+if (courtList) {
+  courtList.addEventListener('click', handleCourtClick);
+}
+if (courtForm) {
+  courtForm.addEventListener('submit', handleCourtForm);
+}
+
+applyPayload(initial);
+updateUI();

--- a/static/js/translations.js
+++ b/static/js/translations.js
@@ -53,10 +53,18 @@ export const TRANSLATIONS = {
       empty: 'Brak zapisanych wyników.',
       columns: {
         description: 'Mecz',
-        duration: 'Czas'
+        duration: 'Czas',
+        category: 'Kategoria',
+        phase: 'Faza rozgrywek'
       },
       labels: {
         supertb: 'Wynik SUPERTB'
+      },
+      defaults: {
+        phase: 'Grupowa'
+      },
+      placeholders: {
+        category: '—'
       }
     },
     accessibility: {
@@ -124,10 +132,18 @@ export const TRANSLATIONS = {
       empty: 'Keine gespeicherten Ergebnisse.',
       columns: {
         description: 'Begegnung',
-        duration: 'Dauer'
+        duration: 'Dauer',
+        category: 'Kategorie',
+        phase: 'Turnierphase'
       },
       labels: {
         supertb: 'Super-Tiebreak'
+      },
+      defaults: {
+        phase: 'Gruppenphase'
+      },
+      placeholders: {
+        category: '—'
       }
     },
     accessibility: {
@@ -191,10 +207,18 @@ export const TRANSLATIONS = {
       empty: 'No saved results.',
       columns: {
         description: 'Match',
-        duration: 'Duration'
+        duration: 'Duration',
+        category: 'Category',
+        phase: 'Stage'
       },
       labels: {
         supertb: 'Super tiebreak'
+      },
+      defaults: {
+        phase: 'Group stage'
+      },
+      placeholders: {
+        category: '—'
       }
     },
     shortcuts: { desc: 'Shortcuts: [1–6] courts, H – history.' },
@@ -260,10 +284,18 @@ export const TRANSLATIONS = {
       empty: 'Nessun risultato salvato.',
       columns: {
         description: 'Incontro',
-        duration: 'Durata'
+        duration: 'Durata',
+        category: 'Categoria',
+        phase: 'Fase'
       },
       labels: {
         supertb: 'Super tie-break'
+      },
+      defaults: {
+        phase: 'Fase a gironi'
+      },
+      placeholders: {
+        category: '—'
       }
     },
     accessibility: {
@@ -328,10 +360,18 @@ export const TRANSLATIONS = {
       empty: 'No hay resultados guardados.',
       columns: {
         description: 'Partido',
-        duration: 'Duración'
+        duration: 'Duración',
+        category: 'Categoría',
+        phase: 'Fase'
       },
       labels: {
         supertb: 'Resultado super desempate'
+      },
+      defaults: {
+        phase: 'Fase de grupos'
+      },
+      placeholders: {
+        category: '—'
       }
     },
     accessibility: {

--- a/wyniki/config.py
+++ b/wyniki/config.py
@@ -60,6 +60,13 @@ class Settings:
 
     overlay_base: str = os.environ.get("UNO_BASE", "https://app.overlays.uno/apiv2/controlapps")
     uno_auth_bearer: str = os.environ.get("UNO_AUTH_BEARER", "").strip()
+    admin_password: str = os.environ.get("ADMIN_PASSWORD", "").strip()
+    secret_key: str = (
+        os.environ.get("FLASK_SECRET_KEY")
+        or os.environ.get("SECRET_KEY")
+        or os.environ.get("APP_SECRET_KEY")
+        or "wyniki-secret-key"
+    )
     rpm_per_court: int = int(os.environ.get("RPM_PER_COURT", "55"))
     burst: int = int(os.environ.get("BURST", "8"))
     db_path: str = os.environ.get("DB_PATH", "wyniki_archive.sqlite3")

--- a/wyniki/courts.py
+++ b/wyniki/courts.py
@@ -1,0 +1,118 @@
+"""Helpers for managing court overlay configuration."""
+from __future__ import annotations
+
+import threading
+from typing import Dict, List, Optional, Tuple
+
+from .config import log, normalize_overlay_id, settings
+from .database import delete_court as db_delete_court
+from .database import fetch_courts as db_fetch_courts
+from .database import upsert_court as db_upsert_court
+
+_LOCK = threading.RLock()
+_COURTS: Dict[str, Optional[str]] = {}
+
+
+def _sort_key(kort_id: str) -> Tuple[int, str]:
+    try:
+        return (0, f"{int(str(kort_id)) :04d}")
+    except (TypeError, ValueError):
+        return (1, str(kort_id))
+
+
+def _normalize_kort_id(value: str) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.isdigit():
+        try:
+            return str(int(text))
+        except ValueError:
+            return text
+    return text
+
+
+def reload_courts() -> Dict[str, Optional[str]]:
+    mapping: Dict[str, Optional[str]] = {}
+    for row in db_fetch_courts() or []:
+        kort_id = _normalize_kort_id(row["kort_id"])
+        if not kort_id:
+            continue
+        overlay_id = row["overlay_id"]
+        normalized_overlay = normalize_overlay_id(overlay_id) or (overlay_id.strip() if isinstance(overlay_id, str) else None)
+        mapping[kort_id] = normalized_overlay
+    if not mapping and settings.overlay_ids:
+        mapping = {str(k): v for k, v in settings.overlay_ids.items()}
+    with _LOCK:
+        global _COURTS
+        _COURTS = mapping
+    return dict(mapping)
+
+
+def get_overlay_map() -> Dict[str, Optional[str]]:
+    with _LOCK:
+        if not _COURTS:
+            reload_courts()
+        return dict(_COURTS)
+
+
+def list_courts() -> List[Tuple[str, Optional[str]]]:
+    mapping = get_overlay_map()
+    if not mapping:
+        return []
+    return sorted(mapping.items(), key=lambda item: _sort_key(item[0]))
+
+
+def overlay_id_to_kort_map() -> Dict[str, str]:
+    mapping = get_overlay_map()
+    return {overlay: kort for kort, overlay in mapping.items() if overlay}
+
+
+def get_overlay_for_kort(kort_id: str) -> Optional[str]:
+    normalized = _normalize_kort_id(kort_id)
+    if not normalized:
+        return None
+    return get_overlay_map().get(normalized)
+
+
+def upsert_court(kort_id: str, overlay_id: str) -> Dict[str, Optional[str]]:
+    normalized_kort = _normalize_kort_id(kort_id)
+    normalized_overlay = normalize_overlay_id(overlay_id)
+    if not normalized_kort:
+        raise ValueError("Kort ID cannot be empty")
+    if not normalized_overlay:
+        raise ValueError("Overlay ID cannot be empty")
+    db_upsert_court(normalized_kort, normalized_overlay)
+    log.info("court upsert kort=%s overlay=%s", normalized_kort, normalized_overlay)
+    return reload_courts()
+
+
+def delete_court(kort_id: str) -> bool:
+    normalized_kort = _normalize_kort_id(kort_id)
+    if not normalized_kort:
+        return False
+    deleted = db_delete_court(normalized_kort)
+    if deleted:
+        log.info("court delete kort=%s", normalized_kort)
+        reload_courts()
+    return deleted
+
+
+def ensure_loaded() -> None:
+    get_overlay_map()
+
+
+ensure_loaded()
+
+__all__ = [
+    "delete_court",
+    "ensure_loaded",
+    "get_overlay_for_kort",
+    "get_overlay_map",
+    "list_courts",
+    "overlay_id_to_kort_map",
+    "reload_courts",
+    "upsert_court",
+]

--- a/wyniki/database.py
+++ b/wyniki/database.py
@@ -64,6 +64,8 @@ def init_db() -> None:
               duration_seconds INTEGER NOT NULL,
               player_a TEXT,
               player_b TEXT,
+              category TEXT,
+              phase TEXT DEFAULT 'Grupowa',
               set1_a INTEGER,
               set1_b INTEGER,
               set2_a INTEGER,
@@ -74,6 +76,15 @@ def init_db() -> None:
               set1_tb_b INTEGER DEFAULT 0,
               set2_tb_a INTEGER DEFAULT 0,
               set2_tb_b INTEGER DEFAULT 0
+            );
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS courts (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              kort_id TEXT NOT NULL UNIQUE,
+              overlay_id TEXT NOT NULL
             );
             """
         )
@@ -89,6 +100,22 @@ def init_db() -> None:
         for column, statement in tie_columns.items():
             if column not in existing_columns:
                 cursor.execute(statement)
+        if "category" not in existing_columns:
+            cursor.execute("ALTER TABLE match_history ADD COLUMN category TEXT")
+        if "phase" not in existing_columns:
+            cursor.execute("ALTER TABLE match_history ADD COLUMN phase TEXT DEFAULT 'Grupowa'")
+            cursor.execute(
+                "UPDATE match_history SET phase = 'Grupowa' WHERE phase IS NULL OR TRIM(phase) = ''"
+            )
+
+        cursor.execute("SELECT kort_id FROM courts")
+        existing_courts = {row["kort_id"] for row in cursor.fetchall()}
+        for kort_id, overlay_id in settings.overlay_ids.items():
+            if overlay_id and kort_id not in existing_courts:
+                cursor.execute(
+                    "INSERT INTO courts (kort_id, overlay_id) VALUES (?, ?)",
+                    (str(kort_id), overlay_id),
+                )
         connection.commit()
 
 
@@ -119,7 +146,8 @@ def fetch_recent_history(limit: int) -> Iterable[sqlite3.Row]:
         cursor = connection.cursor()
         cursor.execute(
             """
-            SELECT kort_id, ended_ts, duration_seconds, player_a, player_b,
+            SELECT id, kort_id, ended_ts, duration_seconds, player_a, player_b,
+                   category, phase,
                    set1_a, set1_b, set2_a, set2_b, tie_a, tie_b,
                    set1_tb_a, set1_tb_b, set2_tb_a, set2_tb_b
             FROM match_history
@@ -131,16 +159,34 @@ def fetch_recent_history(limit: int) -> Iterable[sqlite3.Row]:
         return cursor.fetchall()
 
 
-def insert_match_history(entry: Dict[str, object]) -> None:
+def fetch_match_history_entry(entry_id: int) -> Optional[sqlite3.Row]:
+    with db_conn() as connection:
+        cursor = connection.cursor()
+        cursor.execute(
+            """
+            SELECT id, kort_id, ended_ts, duration_seconds, player_a, player_b,
+                   category, phase,
+                   set1_a, set1_b, set2_a, set2_b, tie_a, tie_b,
+                   set1_tb_a, set1_tb_b, set2_tb_a, set2_tb_b
+            FROM match_history
+            WHERE id = ?
+            """,
+            (entry_id,),
+        )
+        return cursor.fetchone()
+
+
+def insert_match_history(entry: Dict[str, object]) -> int:
     with db_conn() as connection:
         cursor = connection.cursor()
         cursor.execute(
             """
             INSERT INTO match_history (
                 kort_id, ended_ts, duration_seconds, player_a, player_b,
+                category, phase,
                 set1_a, set1_b, set2_a, set2_b, tie_a, tie_b,
                 set1_tb_a, set1_tb_b, set2_tb_a, set2_tb_b
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 entry.get("kort"),
@@ -148,6 +194,8 @@ def insert_match_history(entry: Dict[str, object]) -> None:
                 entry.get("duration_seconds", 0),
                 entry.get("player_a"),
                 entry.get("player_b"),
+                entry.get("category"),
+                entry.get("phase", "Grupowa"),
                 entry.get("set1_a", 0),
                 entry.get("set1_b", 0),
                 entry.get("set2_a", 0),
@@ -161,6 +209,70 @@ def insert_match_history(entry: Dict[str, object]) -> None:
             ),
         )
         connection.commit()
+        return int(cursor.lastrowid)
+
+
+def update_match_history_entry(entry_id: int, updates: Dict[str, object]) -> bool:
+    assignments = []
+    values = []
+    for key in ("player_a", "player_b", "category", "phase"):
+        if key in updates:
+            assignments.append(f"{key} = ?")
+            values.append(updates[key])
+    if not assignments:
+        return False
+    values.append(entry_id)
+    with db_conn() as connection:
+        cursor = connection.cursor()
+        cursor.execute(
+            f"UPDATE match_history SET {', '.join(assignments)} WHERE id = ?",
+            tuple(values),
+        )
+        connection.commit()
+        return cursor.rowcount > 0
+
+
+def delete_match_history_entry_by_id(entry_id: int) -> bool:
+    with db_conn() as connection:
+        cursor = connection.cursor()
+        cursor.execute("DELETE FROM match_history WHERE id = ?", (entry_id,))
+        connection.commit()
+        return cursor.rowcount > 0
+
+
+def fetch_courts() -> Iterable[sqlite3.Row]:
+    with db_conn() as connection:
+        cursor = connection.cursor()
+        cursor.execute(
+            """
+            SELECT kort_id, overlay_id
+            FROM courts
+            ORDER BY CAST(kort_id AS INTEGER), kort_id
+            """
+        )
+        return cursor.fetchall()
+
+
+def upsert_court(kort_id: str, overlay_id: str) -> None:
+    with db_conn() as connection:
+        cursor = connection.cursor()
+        cursor.execute(
+            """
+            INSERT INTO courts (kort_id, overlay_id)
+            VALUES (?, ?)
+            ON CONFLICT(kort_id) DO UPDATE SET overlay_id = excluded.overlay_id
+            """,
+            (kort_id, overlay_id),
+        )
+        connection.commit()
+
+
+def delete_court(kort_id: str) -> bool:
+    with db_conn() as connection:
+        cursor = connection.cursor()
+        cursor.execute("DELETE FROM courts WHERE kort_id = ?", (kort_id,))
+        connection.commit()
+        return cursor.rowcount > 0
 
 
 def delete_latest_history_entry(kort_id: Optional[str] = None) -> Optional[Dict[str, object]]:
@@ -170,6 +282,7 @@ def delete_latest_history_entry(kort_id: Optional[str] = None) -> Optional[Dict[
             cursor.execute(
                 """
                 SELECT id, kort_id, ended_ts, duration_seconds, player_a, player_b,
+                       category, phase,
                        set1_a, set1_b, set2_a, set2_b, tie_a, tie_b,
                        set1_tb_a, set1_tb_b, set2_tb_a, set2_tb_b
                 FROM match_history
@@ -183,6 +296,7 @@ def delete_latest_history_entry(kort_id: Optional[str] = None) -> Optional[Dict[
             cursor.execute(
                 """
                 SELECT id, kort_id, ended_ts, duration_seconds, player_a, player_b,
+                       category, phase,
                        set1_a, set1_b, set2_a, set2_b, tie_a, tie_b,
                        set1_tb_a, set1_tb_b, set2_tb_a, set2_tb_b
                 FROM match_history
@@ -201,6 +315,8 @@ def delete_latest_history_entry(kort_id: Optional[str] = None) -> Optional[Dict[
         "duration_seconds": row["duration_seconds"],
         "player_a": row["player_a"],
         "player_b": row["player_b"],
+        "category": row["category"],
+        "phase": row["phase"],
         "set1_a": row["set1_a"],
         "set1_b": row["set1_b"],
         "set2_a": row["set2_a"],
@@ -218,10 +334,16 @@ init_db()
 
 __all__ = [
     "db_conn",
+    "delete_court",
     "delete_latest_history_entry",
+    "delete_match_history_entry_by_id",
+    "fetch_courts",
+    "fetch_match_history_entry",
     "fetch_recent_history",
     "fetch_state_cache",
     "init_db",
     "insert_match_history",
+    "update_match_history_entry",
     "upsert_state_cache",
+    "upsert_court",
 ]

--- a/wyniki/web.py
+++ b/wyniki/web.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 from flask import Flask
 
 from . import routes
+from .config import settings
 
 
 def create_app() -> Flask:
     app = Flask(__name__, static_folder=None)
+    app.secret_key = settings.secret_key
     routes.register_routes(app)
     return app
 


### PR DESCRIPTION
## Summary
- add a password-protected `/admin` panel with styling and frontend logic for editing match history metadata and managing court overlays stored in the database
- extend the database and state management layers with court persistence, id-aware history serialization, and admin-only APIs for updating or deleting entries
- document the new configuration requirements, including `FLASK_SECRET_KEY`, and ensure the Flask app initializes its secret key

## Testing
- python -m compileall wyniki static/js

------
https://chatgpt.com/codex/tasks/task_e_68ea352dd260832a9b34dc7d20e661cd