### PR TITLE
Add admin reset control and defer set highlight after matches

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -69,6 +69,7 @@
                 <td class="kort-id">{{ court.kort_id }}</td>
                 <td class="overlay-id">{{ court.overlay_id or '' }}</td>
                 <td class="actions">
+                  <button class="reset-court" type="button">Resetuj</button>
                   <button class="delete-court" type="button">Usuń</button>
                 </td>
               </tr>

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -169,10 +169,15 @@
 
     const actionsCell = document.createElement('td');
     actionsCell.className = 'actions';
+    const resetButton = document.createElement('button');
+    resetButton.type = 'button';
+    resetButton.className = 'reset-court';
+    resetButton.textContent = 'Resetuj';
     const deleteButton = document.createElement('button');
     deleteButton.type = 'button';
     deleteButton.className = 'delete-court';
     deleteButton.textContent = 'Usuń';
+    actionsCell.appendChild(resetButton);
     actionsCell.appendChild(deleteButton);
     row.appendChild(actionsCell);
 
@@ -378,6 +383,25 @@
     }
   }
 
+  async function resetCourtState(kortId) {
+    if (!kortId) {
+      setFeedback('Nie udało się odczytać identyfikatora kortu.', 'error');
+      return;
+    }
+    if (!window.confirm(`Czy na pewno wyzerować stan kortu ${kortId}?`)) {
+      return;
+    }
+    try {
+      const data = await requestJson(`/api/admin/courts/${encodeURIComponent(kortId)}/reset`, {
+        method: 'POST'
+      });
+      const message = (data && (data.message || data.detail)) || `Kort ${kortId} został wyzerowany.`;
+      setFeedback(message, 'success');
+    } catch (error) {
+      setFeedback(error.message, 'error');
+    }
+  }
+
   async function deleteEntry(row) {
     const entryId = row.dataset.entryId;
     if (!entryId) {
@@ -417,11 +441,14 @@
     if (!(target instanceof HTMLElement)) {
       return;
     }
-    if (target.classList.contains('delete-court')) {
-      const row = target.closest('tr[data-kort-id]');
-      if (row) {
-        deleteCourtRow(row);
-      }
+    const row = target.closest('tr[data-kort-id]');
+    if (!row) {
+      return;
+    }
+    if (target.classList.contains('reset-court')) {
+      resetCourtState(row.dataset.kortId || '');
+    } else if (target.classList.contains('delete-court')) {
+      deleteCourtRow(row);
     }
   }
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -507,6 +507,15 @@ function updatePointsLabelText(k, tieVisible, isSuperTieBreak) {
   }
 }
 
+function normalizeCurrentSetValue(raw) {
+  if (raw === undefined || raw === null) return 0;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || Number.isNaN(parsed) || parsed <= 0) {
+    return 0;
+  }
+  return parsed;
+}
+
 function applyScoreAria(k, data) {
   const section = document.getElementById(`kort-${k}`);
   if (!section) return;
@@ -515,7 +524,7 @@ function applyScoreAria(k, data) {
   const summaryRoot = document.getElementById(`k${k}-summary`);
   const t = currentT();
   const acc = resolveAccessibilityStrings(t);
-  const currentSet = Number(data.current_set || 1);
+  const currentSet = normalizeCurrentSetValue(data.current_set);
   const tieState = data.tie || {};
   const tieVisible = tieState.visible === true;
   const isSuperTieBreak = tieVisible && currentSet === 3;
@@ -884,7 +893,7 @@ function updateCourt(k, data) {
   handleTieScoreAnnouncements(k, tieNow, tiePrev, surnames);
   applyScoreAria(k, dataWithTie);
 
-  applySetHighlight(k, data.current_set ?? 1);
+  applySetHighlight(k, data.current_set);
 }
 
 function normalizePointsDisplay(value) {
@@ -985,7 +994,7 @@ function updatePlayerFlag(k, side, current, previous) {
 }
 
 function applySetHighlight(k, currentSet) {
-  const active = Number(currentSet || 1);
+  const active = normalizeCurrentSetValue(currentSet);
   ['1', '2', '3'].forEach(idx => {
     ['A', 'B'].forEach(side => {
       const cell = document.getElementById(`k${k}-s${idx}-${side}`);
@@ -1316,7 +1325,7 @@ function refreshCardsLanguage() {
     }
     updatePlayerFlag(k, 'A', prev[k]?.A || {}, {});
     updatePlayerFlag(k, 'B', prev[k]?.B || {}, {});
-    applySetHighlight(k, prev[k]?.current_set ?? 1);
+    applySetHighlight(k, prev[k]?.current_set);
     const historyTitle = section.querySelector('.history-title');
     if (historyTitle && t.history?.title) historyTitle.textContent = t.history.title;
     if (prev[k]) {


### PR DESCRIPTION
## Summary
- add an authenticated admin endpoint and UI control to reset a court without writing a history entry
- reset the scoreboard state to clear the active set after a match and wait for real play to restart before highlighting set 1
- update the public UI to tolerate a cleared current_set value so the highlight only appears once play resumes

## Testing
- `python - <<'PY'
from wyniki.state import ensure_court_state, apply_local_command, reset_after_match

kort_id = "test-reset"
state = ensure_court_state(kort_id)
reset_after_match(state)

apply_local_command(state, "SetNamePlayerA", "Player A", None, kort_id)
apply_local_command(state, "SetNamePlayerB", "Player B", None, kort_id)

apply_local_command(state, "SetSet1PlayerA", 4, None, kort_id)
apply_local_command(state, "SetSet1PlayerB", 0, None, kort_id)
print("after set1", state["A"]["set1"], state["B"]["set1"], state["current_set"])
apply_local_command(state, "SetSet2PlayerA", 4, None, kort_id)
apply_local_command(state, "SetSet2PlayerB", 0, None, kort_id)
print("after match", state["A"]["set1"], state["B"]["set1"], state["A"]["set2"], state["B"]["set2"], state["current_set"], state["tie"], state["match_status"])

apply_local_command(state, "SetNamePlayerA", "Next Player A", None, kort_id)
apply_local_command(state, "SetNamePlayerB", "Next Player B", None, kort_id)
print("after names", state["current_set"], state["A"]["points"], state["B"]["points"])
apply_local_command(state, "IncreasePointsPlayerA", None, None, kort_id)
print("after first point", state["current_set"], state["A"]["points"], state["B"]["points"])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ec3233ec54832a8f1b2d502aeb0d8d