### PR TITLE
Stream lean snapshots and decouple history updates

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1076,8 +1076,6 @@ function handleStreamPayload(payload) {
 
   if (payload.type === 'snapshot') {
     const state = payload.state || {};
-    latestHistory = Array.isArray(payload.history) ? payload.history : latestHistory;
-    renderGlobalHistory(latestHistory);
     ensureCardsFromSnapshot(state);
     const keys = computeCourts(state);
     COURTS = keys;
@@ -1089,6 +1087,15 @@ function handleStreamPayload(payload) {
     const snapshotTime = parseTimestamp(payload.ts) || new Date();
     updateLastRefresh(snapshotTime);
     persistSnapshot(prev, latestHistory, snapshotTime.toISOString());
+    return;
+  }
+
+  if (payload.type === 'history-update') {
+    latestHistory = Array.isArray(payload.history) ? payload.history : [];
+    renderGlobalHistory(latestHistory);
+    const historyTime = parseTimestamp(payload.ts) || new Date();
+    updateLastRefresh(historyTime);
+    persistSnapshot(prev, latestHistory, historyTime.toISOString());
     return;
   }
 
@@ -1370,7 +1377,9 @@ async function bootstrap() {
     return;
   }
   const state = snapshot.state || {};
-  latestHistory = Array.isArray(snapshot.history) ? snapshot.history : [];
+  if (Array.isArray(snapshot.history)) {
+    latestHistory = snapshot.history;
+  }
   renderGlobalHistory(latestHistory);
   ensureCardsFromSnapshot(state);
   const computedCourts = computeCourts(state);


### PR DESCRIPTION
## Summary
- trim public court serialization to only scoreboard fields and flag history changes for deferred broadcasts
- send snapshot and history as separate SSE events so the initial payload excludes the heavy history list
- update the frontend stream handler to consume the new history-update event and keep cached data in sync

## Testing
- python -m compileall wyniki

------
https://chatgpt.com/codex/tasks/task_e_68ee9545360c832ab2ec9a86ccc714a9