### PR TITLE
Propozycja redesignu WWW: turniej jako kontekst

### DIFF
--- a/wyniki-v2/docs/PUBLIC_UI_REDESIGN.md
+++ b/wyniki-v2/docs/PUBLIC_UI_REDESIGN.md
@@ -1,0 +1,129 @@
+# Redesign publicznego WWW: turniej jako kontekst
+
+Propozycja, nie wdrożenie. Backend, kontrakt SSE/`/api/snapshot`, Alpine i silnik punktacji zostają. Zmienia się tylko to, jak publiczna strona układa te same dane.
+
+Klikalny podgląd: [redesign-preview.html](./redesign-preview.html).
+
+## Po co to w ogóle
+
+JS publicznego frontu jest już poukładany (`refaktor.md`, etap 8 zamknięty). To, co nadal boli na korcie, to nie brak modułów — to **mapa informacji**.
+
+Dziś użytkownik ma dwie równoległe hierarchie:
+
+```text
+Na żywo
+  ├─ Wyniki live
+  ├─ Drabinka
+  ├─ Terminarz
+  └─ Historia
+Turnieje / Historia          ← w PL przycisk mówi „Historia”, w i18n „Turnieje”
+  ├─ Drabinka
+  ├─ Terminarz
+  └─ Historia meczów
+Zawodnicy
+```
+
+Drabinka, plan i wyniki istnieją dwa razy. Zakładka nadrzędna „Na żywo” ukrywa terminarza i drabinkę za drugą warstwą kart. Na telefonie znikają dwa rzędy nawigacji, zanim widać wynik. Biuro (`office.html`) i admin żyją w innym świecie wizualnym (DaisyUI z CDN, ciepła paleta, inne radiusy) niż publiczny scoreboard (własny CSS, ciemny header nawet w trybie jasnym).
+
+To nie jest problem „zrób ładniej”. To problem **gdzie kliknąć, gdy mecz właśnie się zaczął**.
+
+## Zasada
+
+**Turniej jest kontekstem, nie zakładką.**
+
+Wybór turnieju siedzi w nagłówku. Pięć widoków operuje na tym samym turnieju:
+
+```text
+[ Logo  Turniej ▾  LIVE ]                         [ PL  ☾ ]
+
+  Korty  ·  Terminarz  ·  Drabinka  ·  Wyniki  ·  Zawodnicy
+```
+
+Na telefonie ta sama piątka schodzi na dół (strefa kciuka). Żadnej drugiej warstwy zakładek.
+
+| Dziś | Po zmianie |
+|------|------------|
+| Live / Turnieje / Zawodnicy + 4 karty pod Live | 5 równorzędnych widoków |
+| Turniej wybierasz wchodząc w „Turnieje” | Selektor w headerze, aktywny turniej jest domyślny |
+| Drabinka live ≠ drabinka historii | Jeden widok, dane zależą od wybranego turnieju |
+| Historia live vs historia turnieju | Jeden widok **Wyniki** (zakończone mecze) |
+| Header zawsze ciemny | Ciemny scoreboard jest trybem, nie wyjątkiem |
+
+Poza sezonem (brak aktywnego turnieju) **Korty** pokazują pusty stan i kartę nadchodzącego / ostatniego turnieju. Archiwum to ten sam shell z wyłączoną plakietką LIVE.
+
+## Dla kogo
+
+Publiczne WWW jest używane głównie na korcie: telefon w słońcu albo w cieniu, jedna ręka, czasem czytnik ekranu. Kolejność pytań:
+
+1. Co się dzieje **teraz**?
+2. Kiedy gram / kiedy gra X?
+3. Jak wygląda moja grupa / drabinka?
+4. Co się właśnie skończyło?
+5. Kim jest zawodnik, którego nie znam?
+
+Dlatego **Korty** są defaultem, a nie „Na żywo → Wyniki live”. Terminarz i drabinka nie mogą być schowane za drugą zakładką.
+
+## Język wizualny
+
+Nie przepisujemy DaisyUI na publiczny WWW i nie dokładamy fontów z Google na stronę wyników (biuro może zostawić Outfit). Publiczny scoreboard zostaje przy `system-ui` i istniejących tokenach, z trzema korektami:
+
+| Token | Propozycja | Skąd |
+|-------|------------|------|
+| Tło scoreboardu | `#0b0f14` | już `--bg` w dark |
+| Akcent LIVE | `#c6e953` (piłka serwisowa) | już SVG serwisu |
+| Status OK | `#35c46a` | już `--ok` |
+| Akcja / link | `#9ad1ff` | już `--accent` dark |
+| Biuro (osobna skóra) | teal `#0f766e` + warm paper | zostaje, ale te same radiusy i 44px hit-area |
+
+Ciemny tryb jest **domyślny na widoku Korty** (kontrast na dworze, telewizor, overlay). Jasny tryb zostaje dla terminarza/archiwum i preferencji systemowej. Nie robimy osobnej skóry „jak ATP” ani „jak FlashScore” — te serwisy są gęste i desktopowe. Tu liczby muszą być czytelne z metra.
+
+Wspólny atom: **wiersz meczu**. Live, wyniki i wiersz terminarza to ten sam układ: zawodnicy po lewej, sety tabular-nums po prawej, kort + kategoria pod spodem. Różni się tylko czy punkty są żywe.
+
+## Routing (stare hashe zostają)
+
+Nie łamiemy zakładek i linków z SMS / biura.
+
+| Hash dziś | Zachowanie po zmianie |
+|-----------|------------------------|
+| `#` / `#live` / `#live/scores` | widok Korty, aktywny turniej |
+| `#live/bracket`, `#drabinka` | widok Drabinka |
+| `#live/schedule` | widok Terminarz |
+| `#live/history` | widok Wyniki (aktywny turniej) |
+| `#tournaments` | ten sam shell, otwarty selektor turnieju albo lista archiwum |
+| `#tournaments/{id}/…` | ten sam widok co live, inny `tournament_id` |
+| `#players`, `#zawodnicy/…` | bez zmiany znaczenia |
+
+Implementacyjnie: `activeTab` + `liveSubTab` + `historySubTab` składają się do jednego `view`. Stare stany Alpine mapują 1:1, bez drugiego drzewa w `index.html`.
+
+## Czego świadomie nie ruszamy
+
+- API, SSE, snapshot, schemat DB, aplikacja sędziego.
+- Alpine, Vite, i18n, testy a11y/smoke.
+- Osobny `office.html` / `admin.html` w pierwszym podejściu — tylko wspólne tokeny CSS, gdy już ustabilizuje się publiczny shell.
+- DaisyUI na stronie publicznej (zależność jest, ale publiczny CSS jej nie używa; nie mieszamy tego w locie).
+
+To jest zgodne z zamrożeniem architektury: layout i copy są dozwolone, kontrakt punktacji nie.
+
+## Wdrożenie małymi krokami
+
+Jak `refaktor.md`: jeden wycinek, `npm run check:public`, smoke.
+
+1. **Tokeny** — wyciągnąć `:root` / `[data-theme]` z `main.css` do `src/tokens.css`. Zero zmiany wyglądu.
+2. **Selektor turnieju w headerze** — aktywny turniej z snapshotu; lista z `/api/tournaments`. Zakładka Turnieje jeszcze zostaje.
+3. **Spłaszczenie nawigacji** — pięć przycisków pierwszego rzędu; `liveSubTab` i `historySubTab` znikają z DOM, zostają jako alias stanu. Na `<md` dolny pasek.
+4. **Wspólny wiersz meczu** — live karta kortu i historia używają tej samej siatki setów.
+5. **Usunąć duplikat widoków** pod Turnieje: `#tournaments/{id}/bracket` renderuje ten sam panel co `#live/bracket` z innym id.
+6. **Tokeny do biura** — radius, focus ring, 44px, bez zmiany kompozycji office.
+
+Każdy krok da się wycofać bez migracji danych.
+
+## Ryzyka
+
+- **Głębokie linki i e2e** — hash API musi zostać; zmienia się tylko DOM zakładek. Smoke public + a11y tablist.
+- **Dwa źródła turnieju** — snapshot (live) vs lista turniejów. Selektor musi jasno pokazać, który jest aktywny na korcie.
+- **A11y** — dziś są zagnieżdżone `role=tablist`. Cel: jeden tablist główny + filtry (kategoria, kort) jako zwykłe toolbar/radiogroup, nie druga warstwa tabów.
+- **Pusty stan** — gdy nic nie jest live, Korty nie mogą wyglądać jak awaria. Karta „następny turniej” + skok do terminarza.
+
+## Kryterium „wystarczy”
+
+Redesign jest skończony, gdy na telefonie w 10 sekund widać wynik z kortu 1, a drabinka i plan są jednym tapnięciem, bez drugiej warstwy kart. Nie wtedy, gdy strona „wygląda nowocześnie”.

--- a/wyniki-v2/docs/redesign-preview.html
+++ b/wyniki-v2/docs/redesign-preview.html
@@ -1,0 +1,427 @@
+<!DOCTYPE html>
+<html lang="pl" data-theme="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Podgląd redesignu — wyniki</title>
+  <style>
+    :root {
+      --bg: #0b0f14;
+      --bg-elev: #101825;
+      --card: #141c28;
+      --text: #e6edf3;
+      --muted: #9fb1c2;
+      --line: #1e2a3a;
+      --accent: #c6e953;
+      --accent-ink: #141a08;
+      --link: #9ad1ff;
+      --ok: #35c46a;
+      --header: #0b0f14;
+      --nav: #0d131c;
+      --danger: #ff6b6b;
+      --radius: 14px;
+      --focus: #ffe08a;
+      font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+    }
+    [data-theme="light"] {
+      --bg: #f4f6f8;
+      --bg-elev: #fff;
+      --card: #fff;
+      --text: #0f1419;
+      --muted: #5f6b7a;
+      --line: #d1d5db;
+      --accent: #6b8f12;
+      --accent-ink: #fff;
+      --link: #0a5fd0;
+      --ok: #106a34;
+      --header: #1b2430;
+      --nav: #fff;
+      --focus: #0a5fd0;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; background: var(--bg); color: var(--text); }
+    button, select { font: inherit; color: inherit; }
+    :focus-visible { outline: 3px solid var(--focus); outline-offset: 2px; }
+
+    .app {
+      min-height: 100vh;
+      padding-bottom: 84px;
+    }
+
+    .top {
+      position: sticky;
+      top: 0;
+      z-index: 20;
+      background: var(--header);
+      color: #fff;
+      border-bottom: 1px solid rgba(255,255,255,.08);
+    }
+    .top-inner {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 10px 16px;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-weight: 700;
+      letter-spacing: .2px;
+      white-space: nowrap;
+    }
+    .brand-mark {
+      width: 28px; height: 28px; border-radius: 8px;
+      background: var(--accent); color: #141a08;
+      display: grid; place-items: center; font-size: 16px;
+    }
+    .tourney {
+      flex: 1;
+      min-width: 0;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .tourney select {
+      width: min(420px, 100%);
+      min-height: 44px;
+      border-radius: 10px;
+      border: 1px solid rgba(255,255,255,.22);
+      background: rgba(255,255,255,.1);
+      color: #fff;
+      padding: 0 12px;
+    }
+    .tourney select option { color: #0f1419; }
+    .live-pill {
+      display: inline-flex; align-items: center; gap: 6px;
+      padding: 4px 10px; border-radius: 999px;
+      background: #d7f2e1; color: #106a34; font-size: 12px; font-weight: 800;
+    }
+    .live-pill i {
+      width: 8px; height: 8px; border-radius: 50%; background: #35c46a;
+      box-shadow: 0 0 8px #35c46a;
+    }
+    .tools { display: flex; gap: 8px; }
+    .icon-btn {
+      min-width: 44px; min-height: 44px; border-radius: 10px;
+      border: 1px solid rgba(255,255,255,.22);
+      background: rgba(255,255,255,.1); cursor: pointer;
+    }
+
+    .desk-nav {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 8px 16px 0;
+      display: flex;
+      gap: 4px;
+    }
+    .desk-nav button {
+      min-height: 44px;
+      padding: 0 14px;
+      border: 0;
+      background: transparent;
+      color: var(--muted);
+      font-weight: 650;
+      cursor: pointer;
+      border-bottom: 3px solid transparent;
+    }
+    .desk-nav button[aria-current="page"] {
+      color: var(--text);
+      border-bottom-color: var(--accent);
+    }
+    [data-theme="light"] .desk-nav button[aria-current="page"] { color: #0f1419; }
+
+    .banner {
+      max-width: 1120px;
+      margin: 12px auto 0;
+      padding: 0 16px;
+    }
+    .banner-inner {
+      display: flex; gap: 10px; align-items: flex-start;
+      padding: 12px 14px; border-radius: var(--radius);
+      background: rgba(198,233,83,.1);
+      border: 1px solid rgba(198,233,83,.28);
+      font-size: 14px;
+    }
+
+    main { max-width: 1120px; margin: 0 auto; padding: 16px; }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 16px;
+    }
+    .court {
+      background: var(--card);
+      border: 1px solid var(--line);
+      border-radius: 18px;
+      overflow: hidden;
+    }
+    .court-h {
+      display: flex; justify-content: space-between; align-items: center;
+      padding: 10px 14px; border-bottom: 1px solid var(--line);
+      font-size: 13px; color: var(--muted); font-weight: 650;
+    }
+    .court-h strong { color: var(--text); font-size: 15px; }
+    .row {
+      display: grid;
+      grid-template-columns: minmax(0, 1.6fr) 64px repeat(3, 48px);
+      align-items: stretch;
+    }
+    .row + .row { border-top: 1px solid var(--line); }
+    .player {
+      display: flex; align-items: center; gap: 8px;
+      padding: 10px 12px; font-weight: 700;
+    }
+    .flag { width: 22px; height: 15px; border-radius: 2px; background: #445; flex: none; }
+    .serve {
+      width: 14px; height: 14px; border-radius: 50%;
+      background: var(--accent); box-shadow: 0 0 0 2px rgba(198,233,83,.25);
+    }
+    .pts, .set {
+      display: grid; place-items: center;
+      font-variant-numeric: tabular-nums;
+      font-weight: 800;
+    }
+    .pts { background: rgba(198,233,83,.12); font-size: 22px; color: var(--accent); }
+    .set { font-size: 18px; color: var(--muted); }
+    .set.on { color: var(--text); }
+    .meta {
+      display: flex; gap: 8px; flex-wrap: wrap;
+      padding: 8px 12px 12px; color: var(--muted); font-size: 12px;
+    }
+    .chip {
+      padding: 2px 8px; border-radius: 999px;
+      background: rgba(154,209,255,.12); color: var(--link); font-weight: 650;
+    }
+
+    table { width: 100%; border-collapse: collapse; background: var(--card); border-radius: 16px; overflow: hidden; }
+    th, td { text-align: left; padding: 12px; border-bottom: 1px solid var(--line); font-size: 14px; }
+    th { color: var(--muted); font-size: 12px; letter-spacing: .4px; text-transform: uppercase; }
+    .st { font-weight: 700; color: var(--ok); }
+    .st.wait { color: var(--muted); }
+
+    .group {
+      background: var(--card); border: 1px solid var(--line); border-radius: 16px; padding: 14px; margin-bottom: 14px;
+    }
+    .group h3 { margin: 0 0 10px; font-size: 15px; }
+    .bar { display: flex; gap: 6px; margin-bottom: 14px; flex-wrap: wrap; }
+    .bar button {
+      min-height: 40px; padding: 0 12px; border-radius: 999px; cursor: pointer;
+      border: 1px solid var(--line); background: var(--bg-elev);
+    }
+    .bar button[aria-pressed="true"] { background: var(--accent); color: var(--accent-ink); border-color: transparent; }
+
+    .player-card {
+      display: flex; justify-content: space-between; align-items: center;
+      padding: 12px 14px; border-bottom: 1px solid var(--line);
+    }
+    .list { background: var(--card); border: 1px solid var(--line); border-radius: 16px; overflow: hidden; }
+
+    .phone-nav {
+      display: none;
+      position: fixed; left: 0; right: 0; bottom: 0;
+      background: var(--nav);
+      border-top: 1px solid var(--line);
+      padding: 6px 8px calc(8px + env(safe-area-inset-bottom));
+      grid-template-columns: repeat(5, 1fr);
+      z-index: 30;
+    }
+    .phone-nav button {
+      border: 0; background: transparent; min-height: 52px; cursor: pointer;
+      color: var(--muted); font-size: 11px; font-weight: 700;
+      display: grid; place-items: center; gap: 2px;
+    }
+    .phone-nav button[aria-current="page"] { color: var(--text); }
+    .phone-nav span { font-size: 16px; }
+
+    .note {
+      margin-top: 18px; color: var(--muted); font-size: 13px; line-height: 1.5;
+    }
+    .now { font-size: 13px; color: var(--muted); margin: 0 0 12px; }
+
+    @media (max-width: 800px) {
+      .grid { grid-template-columns: 1fr; }
+      .desk-nav { display: none; }
+      .phone-nav { display: grid; }
+      .brand-name { display: none; }
+      .tourney select { width: 100%; }
+    }
+  </style>
+</head>
+<body>
+  <div class="app">
+    <header class="top">
+      <div class="top-inner">
+        <div class="brand">
+          <span class="brand-mark" aria-hidden="true">🎾</span>
+          <span class="brand-name">Wyniki</span>
+        </div>
+        <div class="tourney">
+          <label class="sr" for="t" style="position:absolute;left:-999px">Turniej</label>
+          <select id="t">
+            <option selected>Warszawa Open 2026 (aktywny)</option>
+            <option>Poznań Cup 2025</option>
+            <option>Gdańsk Indoor 2025</option>
+          </select>
+          <span class="live-pill"><i></i>LIVE</span>
+        </div>
+        <div class="tools">
+          <select class="icon-btn" aria-label="Język" style="width:auto;padding:0 8px">
+            <option>PL</option><option>EN</option><option>DE</option>
+          </select>
+          <button class="icon-btn" type="button" id="theme" aria-label="Przełącz motyw">☾</button>
+        </div>
+      </div>
+      <nav class="desk-nav" aria-label="Główna nawigacja">
+        <button type="button" data-view="courts" aria-current="page">Korty</button>
+        <button type="button" data-view="schedule">Terminarz</button>
+        <button type="button" data-view="bracket">Drabinka</button>
+        <button type="button" data-view="results">Wyniki</button>
+        <button type="button" data-view="players">Zawodnicy</button>
+      </nav>
+    </header>
+
+    <div class="banner">
+      <div class="banner-inner">Kort 2 opóźniony ok. 20 min. Finał B1 nie wcześniej niż 16:30.</div>
+    </div>
+
+    <main>
+      <section data-panel="courts">
+        <p class="now">Teraz na kortach · Warszawa Open 2026</p>
+        <div class="grid">
+          <article class="court">
+            <div class="court-h"><strong>Kort 1</strong><span class="live-pill"><i></i>LIVE</span></div>
+            <div class="row">
+              <div class="player"><span class="flag" style="background:#dc143c"></span>Kowalski / Nowak <span class="serve" title="serwis"></span></div>
+              <div class="pts">30</div>
+              <div class="set">6</div><div class="set on">4</div><div class="set"></div>
+            </div>
+            <div class="row">
+              <div class="player"><span class="flag" style="background:#0057b7"></span>Schmidt / Müller</div>
+              <div class="pts">15</div>
+              <div class="set">3</div><div class="set on">5</div><div class="set"></div>
+            </div>
+            <div class="meta"><span class="chip">B1 debel</span><span>set 2 · 1:12</span></div>
+          </article>
+          <article class="court">
+            <div class="court-h"><strong>Kort 2</strong><span>nagrzewanie</span></div>
+            <div class="row">
+              <div class="player"><span class="flag" style="background:#fff"></span>Wiśniewska</div>
+              <div class="pts">0</div>
+              <div class="set">0</div><div class="set"></div><div class="set"></div>
+            </div>
+            <div class="row">
+              <div class="player"><span class="flag" style="background:#009246"></span>Rossi</div>
+              <div class="pts">0</div>
+              <div class="set">0</div><div class="set"></div><div class="set"></div>
+            </div>
+            <div class="meta"><span class="chip">B2 singiel</span><span>start ~14:40</span></div>
+          </article>
+        </div>
+      </section>
+
+      <section data-panel="schedule" hidden>
+        <p class="now">Terminarz · dzisiaj · sortowanie po korcie</p>
+        <table>
+          <thead><tr><th>Godz.</th><th>Kort</th><th>Mecz</th><th>Status</th></tr></thead>
+          <tbody>
+            <tr><td>13:00</td><td>1</td><td>Kowalski/Nowak — Schmidt/Müller</td><td class="st">w trakcie</td></tr>
+            <tr><td>14:40</td><td>2</td><td>Wiśniewska — Rossi</td><td class="st wait">plan</td></tr>
+            <tr><td>16:30</td><td>1</td><td>Finał B1</td><td class="st wait">po Korcie 1</td></tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section data-panel="bracket" hidden>
+        <div class="bar" role="toolbar" aria-label="Kategoria">
+          <button type="button" aria-pressed="true">B1 debel</button>
+          <button type="button">B2 singiel</button>
+          <button type="button">B3</button>
+        </div>
+        <div class="group">
+          <h3>Grupa A</h3>
+          <table>
+            <thead><tr><th>Zawodnik</th><th>W</th><th>P</th><th>Sety</th></tr></thead>
+            <tbody>
+              <tr><td>Kowalski / Nowak</td><td>2</td><td>0</td><td>4–1</td></tr>
+              <tr><td>Schmidt / Müller</td><td>1</td><td>1</td><td>3–2</td></tr>
+              <tr><td>Rossi / Bianchi</td><td>0</td><td>2</td><td>0–4</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section data-panel="results" hidden>
+        <p class="now">Zakończone dzisiaj</p>
+        <div class="list">
+          <article class="court" style="border:0;border-radius:0">
+            <div class="row">
+              <div class="player"><span class="flag" style="background:#dc143c"></span>Lewandowska</div>
+              <div class="pts" style="background:transparent;color:var(--text)">2</div>
+              <div class="set on">6</div><div class="set on">6</div><div class="set"></div>
+            </div>
+            <div class="row">
+              <div class="player"><span class="flag" style="background:#000"></span>Dupont</div>
+              <div class="pts" style="background:transparent;color:var(--muted)">0</div>
+              <div class="set">2</div><div class="set">3</div><div class="set"></div>
+            </div>
+            <div class="meta"><span class="chip">B2</span><span>Kort 3 · 48 min</span></div>
+          </article>
+        </div>
+      </section>
+
+      <section data-panel="players" hidden>
+        <p class="now">Baza zawodników · ten sam turniej albo cała kariera</p>
+        <div class="list">
+          <div class="player-card"><span>Anna Lewandowska · PL · B2</span><span>12–4</span></div>
+          <div class="player-card"><span>Piotr Kowalski · PL · B1</span><span>8–3</span></div>
+          <div class="player-card"><span>Giulia Rossi · IT · B2</span><span>6–6</span></div>
+        </div>
+      </section>
+
+      <p class="note">
+        To jest statyczny podgląd pomysłu, nie działająca aplikacja.
+        Te same dane co dziś (snapshot, SSE, drabinka, plan) — inna mapa: turniej w headerze, pięć widoków, na telefonie pasek na dole.
+        Opis: <code>PUBLIC_UI_REDESIGN.md</code>
+      </p>
+    </main>
+  </div>
+
+  <nav class="phone-nav" aria-label="Główna nawigacja">
+    <button type="button" data-view="courts" aria-current="page"><span>🎾</span>Korty</button>
+    <button type="button" data-view="schedule"><span>📅</span>Plan</button>
+    <button type="button" data-view="bracket"><span>🏆</span>Drabinka</button>
+    <button type="button" data-view="results"><span>📋</span>Wyniki</button>
+    <button type="button" data-view="players"><span>👤</span>Gracze</button>
+  </nav>
+
+  <script>
+    const buttons = document.querySelectorAll('[data-view]');
+    const panels = document.querySelectorAll('[data-panel]');
+    function show(view) {
+      buttons.forEach((btn) => {
+        if (btn.dataset.view === view) btn.setAttribute('aria-current', 'page');
+        else btn.removeAttribute('aria-current');
+      });
+      panels.forEach((panel) => {
+        panel.hidden = panel.dataset.panel !== view;
+      });
+    }
+    buttons.forEach((btn) => btn.addEventListener('click', () => show(btn.dataset.view)));
+    document.getElementById('theme').addEventListener('click', () => {
+      const root = document.documentElement;
+      const next = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      root.setAttribute('data-theme', next);
+    });
+    document.querySelectorAll('.bar button').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        btn.parentElement.querySelectorAll('button').forEach((b) => b.setAttribute('aria-pressed', 'false'));
+        btn.setAttribute('aria-pressed', 'true');
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Propozycja, nie wdrożenie. Zero zmian w API, SSE, Alpine i produkcji.

## Pomysł

Publiczny frontend ma już poukładany JS (`refaktor.md`). Boli **mapa informacji**: drabinka, plan i wyniki istnieją dwa razy (pod „Na żywo” i pod „Turnieje”), a na telefonie znikają dwa rzędy zakładek zanim widać wynik.

**Turniej jest kontekstem, nie zakładką.** Selektor w headerze, pięć równorzędnych widoków:

`Korty · Terminarz · Drabinka · Wyniki · Zawodnicy`

Na telefonie ta sama piątka na dole. Stare hashe (`#live/bracket`, `#tournaments/{id}/…`) zostają.

## Artefakty

- `wyniki-v2/docs/PUBLIC_UI_REDESIGN.md` — problem, IA, tokeny, routing, kroki wdrożenia
- `wyniki-v2/docs/redesign-preview.html` — statyczny klikalny podgląd (otwórz w przeglądarce)

## Czego to nie rusza

Backend, kontrakt snapshot/SSE, silnik punktacji, office/admin (poza późniejszymi wspólnymi tokenami CSS). Zgodne z architecture freeze: layout, nie schemat.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e6a1d4d-0dad-443a-85a6-430e5c55fae4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e6a1d4d-0dad-443a-85a6-430e5c55fae4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

